### PR TITLE
Fix backticks formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ the new operators meaning is given in the following table:
 
 
 The order of the operations is the following (from higher precedence
-to lower): `*' > `/` > `%` > `+` > `-` > `!&` > `!|` > `!^` > `<<` > `>>`.
+to lower): `*` > `/` > `%` > `+` > `-` > `!&` > `!|` > `!^` > `<<` > `>>`.
 
 ## **Functions and predicates**
 


### PR DESCRIPTION
### What I changed
- Replaced single quotes (') with backticks (`) in the README for better formatting and readability.

This is my first contribution — thank you!