### PR TITLE
Restore formula-wide BV bail-out in process_quantifier_block

### DIFF
--- a/src/normal_forms.tmpl.h
+++ b/src/normal_forms.tmpl.h
@@ -3498,6 +3498,20 @@ tref process_quantifier_block(tref n, std::function<bool(tref)> skip = is_tref_b
 	using tau = tree<node>;
 	if (!is_child_quantifier<node>(n)) return n;
 
+	// Any BV-typed node anywhere in the formula falls back to anti_prenex.
+	// Narrowing this check to BV-typed block variables only (ac4aac43)
+	// routes tau-quantified blocks with adjacent BV atoms -- e.g. temporal
+	// step formulas mixing tau streams with bv verdict/opcode streams --
+	// into the Boole decomposition, which does not terminate in practical
+	// time on the interpreter (run) path.
+	{
+		auto is_bv_node = [](tref m) {
+			return is_bv_type_family<node>(tau::get(m).get_ba_type());
+		};
+		if (tau::get(n).find_top(is_bv_node))
+			return anti_prenex<node>(n);
+	}
+
 	// Collect the maximal same-type block at the top.
 	trefs block_vars;
 	const bool is_ex = is_child<node>(n, tau::wff_ex);


### PR DESCRIPTION
Fixes #70 (interpreter/run path stalls on specs mixing tau and bv streams).

## What

Re-adds the pre-ac4aac43 check at the top of `process_quantifier_block`: if any BV-typed
node occurs anywhere in the formula, fall back to `anti_prenex` for the whole block
(11 lines, no other changes).

## Why

Since ac4aac43 the bail-out triggers only when the block's own quantified variables are
BV-typed. Tau-quantified blocks whose body carries adjacent BV atoms - the shape the
interpreter produces for step formulas mixing tau streams with bv verdict/opcode streams -
now enter the Boole decomposition and no longer terminate in practical time. See the
linked issue for the bisect log, mechanism and minimal repro.

## Verification (one box; ratios are the point)

- Ratchet-family specs execute again: golden 5-step session produces the expected verdict
  sequence; a 12-file demo suite that fails 5/12 on current main passes 12/12.
- The antiprenexing interpreter gains survive: 20-clause seal step ~2.8x faster than the
  `3dbd44be` baseline (vs. never completing on unpatched main).
- The two regression tests introduced in ac4aac43 still pass (checked via `normalize`;
  they assert results, not routing).
- One-off `sat`/`valid`/`normalize` behavior unchanged (the formulas of the known
  satisfiable-sat performance issue contain no BV atoms, so this guard does not affect
  them either way).

## Trade-off

This re-widens the bail-out and thereby undoes the ac4aac43 optimization for non-BV blocks
with unrelated BV atoms on the one-off normalization path. If that optimization should be
kept there, an alternative is to keep the narrow guard for one-off normalization and apply
the formula-wide bail-out only on the interpreter path - happy to rework the PR that way.