### PR TITLE
Opt-in connected-support-component factoring on the sat path (addresses the exponential disjoint-support case from #72)

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -130,6 +130,11 @@ struct api {
 	static void set_json(bool state);
 	/** @brief Set the active Boost.Log severity threshold. */
 	static void set_severity(severity_level level);
+	/** @brief Enable/disable connected-support-component factoring of
+	 *  top-level conjunctions on the sat path (issue #72). Off by default;
+	 *  the TAU_FACTOR_SAT environment variable also enables it (read once,
+	 *  for benchmarking from the CLI). */
+	static void set_component_factoring(bool state);
 
 	// -----------------------------------------------------------------------
 	// Parsing

--- a/src/api.tmpl.h
+++ b/src/api.tmpl.h
@@ -5,6 +5,10 @@
 #include "sbf_parser.generated.h"
 #include "tau_tree_builders.h"
 
+#include <cstdlib>
+#include <functional>
+#include <map>
+
 #undef LOG_CHANNEL_NAME
 #define LOG_CHANNEL_NAME "api"
 
@@ -404,9 +408,122 @@ tref api<node>::eliminate_quantifiers(tref fm) {
 	return nullptr;
 }
 
+// --- Connected-support-component factoring on the sat path (issue #72) ------
+// sat(always(C1 && ... && Cn)) over pairwise DISJOINT variable supports
+// factorizes: the whole is satisfiable iff every support component is.
+// Rationale: models over disjoint stream sets compose pointwise, and a
+// winning strategy for each component composes to one for the whole
+// (component decomposition: Bayardo/Pehoushek, AAAI 2000; additive
+// partitioned representations: Burch/Clarke/Long, 1991/94). Guarded to the
+// provably safe case only: the root is a conjunction (optionally under ONE
+// top-level `always`), and every conjunct is free of nested temporal
+// operators, definition references and non-bv BA constants (a tau-typed
+// constant embeds a formula and could couple components invisibly).
+// Everything else falls through to the stock path unchanged. Off by
+// default: opt in via api::set_component_factoring(true) or the
+// TAU_FACTOR_SAT environment variable (read once; CLI benchmarking).
+inline bool component_factoring = false;
+
+template <NodeType node>
+void api<node>::set_component_factoring(bool state) {
+	component_factoring = state;
+}
+
+template <NodeType node>
+bool tau_factor_components_sat(tref fm, bool& result) {
+	using tau = tree<node>;
+	static const bool env_enabled = std::getenv("TAU_FACTOR_SAT") != nullptr;
+	if ((!component_factoring && !env_enabled) || !fm) return false;
+	tref inner = fm;
+	bool wrapped = false;
+	if (tau::get(inner).child_is(tau::wff_always)) {
+		inner = tau::trim2(inner);
+		wrapped = true;
+	}
+	if (!tau::get(inner).child_is(tau::wff_and)) return false;
+	trefs conjs = get_cnf_wff_clauses<node>(inner);
+	if (conjs.size() < 2) return false;
+	// Unsafe inside a conjunct: nested temporal operators, definition
+	// references, and REAL non-bv BA constants (a {...}-constant embeds a
+	// formula that could couple components invisibly). Plain bf_t/bf_f
+	// literals (the 0/1 in `o10[t]=1`) carry a ba_type too but are pure
+	// logic - they must NOT trigger the bail-out.
+	auto unsafe = [](tref n) {
+		const tau& t = tau::get(n);
+		if (t.is(tau::wff_always) || t.is(tau::wff_sometimes)
+		 || t.is(tau::wff_ref) || t.is(tau::bf_ref)) return true;
+		if (t.is_ba_constant()) {
+			const size_t ty = t.get_ba_type();
+			return ty != 0 && !is_bv_type_family<node>(ty);
+		}
+		return false;
+	};
+	for (tref c : conjs)
+		if (tau::get(c).find_top(unsafe) != nullptr) return false;
+	// union-find over conjuncts, joined by shared variable NAMES.
+	// Mirrors get_free_vars' var_depth discipline: collect a variable
+	// node only at depth 0 and never descend into it - the offset
+	// variable `t` inside o1[t] is NOT part of the support (it is the
+	// shared timeline, present in every conjunct; counting it would
+	// merge everything into one component). get_var_name_sid unifies
+	// o1[t], o1[t-1] and o1[0] to the name "o1". Bound-variable names
+	// are included as an over-approximation - over-merging is sound
+	// (it only suppresses a split, never fabricates one).
+	bool support_ok = true;
+	auto support_of = [&support_ok](tref c, std::set<size_t>& out) {
+		size_t var_depth = 0;
+		auto visit = [&](tref m) -> bool {
+			if (is_var_or_capture<node>(m)) {
+				if (var_depth == 0) {
+					size_t sid = get_var_name_sid<node>(m);
+					if (sid) out.insert(sid);
+					else support_ok = false; // unbenennbar
+				}
+				++var_depth;
+			}
+			return true;
+		};
+		auto visit_subtree = [](tref) -> bool { return true; };
+		auto up = [&](tref m) {
+			if (is_var_or_capture<node>(m)) --var_depth;
+		};
+		pre_order<node>(c).search(visit, visit_subtree, up);
+	};
+	std::vector<size_t> parent(conjs.size());
+	for (size_t i = 0; i < parent.size(); ++i) parent[i] = i;
+	std::function<size_t(size_t)> find = [&](size_t x) {
+		return parent[x] == x ? x : parent[x] = find(parent[x]);
+	};
+	std::map<size_t, size_t> owner; // name-sid -> conjunct index
+	for (size_t i = 0; i < conjs.size(); ++i) {
+		std::set<size_t> sup;
+		support_of(conjs[i], sup);
+		if (!support_ok || sup.empty()) return false; // konservativ kein Split
+		for (size_t sid : sup) {
+			auto it = owner.find(sid);
+			if (it == owner.end()) owner[sid] = i;
+			else parent[find(i)] = find(it->second);
+		}
+	}
+	std::map<size_t, trefs> comps;
+	for (size_t i = 0; i < conjs.size(); ++i) comps[find(i)].push_back(conjs[i]);
+	if (comps.size() < 2) return false;
+	LOG_DEBUG << "component factoring: " << conjs.size() << " conjuncts -> "
+		<< comps.size() << " components";
+	result = true;
+	for (auto& [root, group] : comps) {
+		tref part = group.size() == 1 ? group[0]
+			: tau::build_wff_and(group);
+		if (wrapped) part = tau::build_wff_always(part);
+		if (!api<node>::realizable(part)) { result = false; break; }
+	}
+	return true;
+}
+
 template <NodeType node>
 bool api<node>::realizable(tref fm) {
 	fm = simplify(fm);
+	if (bool r; tau_factor_components_sat<node>(fm, r)) return r;
 	return fm && is_formula(fm)
 		&& is_tau_formula_sat<node>(normalize_formula(fm), 0, true);
 }

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TESTS
 	satisfiability4
 	satisfiability5
 	satisfiability6
+	satisfiability_factoring
 	normalizer_helpers
 	sbf1
 	sbf2

--- a/tests/integration/test_integration-satisfiability_factoring.cpp
+++ b/tests/integration/test_integration-satisfiability_factoring.cpp
@@ -1,0 +1,62 @@
+// To view the license please visit https://github.com/IDNI/tau-lang/blob/main/LICENSE.md
+
+// Connected-support-component factoring on the sat path (issue #72).
+// The factoring hook lives in api<node>::realizable, so these cases go
+// through the api sat entry (is_tau_formula_sat directly would bypass it).
+// Off by default; each case that exercises it toggles the runtime switch
+// and restores the default afterwards.
+
+#include "test_integration-satisfiability_helper.h"
+
+using tau_api = api<node_t>;
+
+// Drive sat through the tref route (get_formula_or_term + sat(tref)) - the
+// path API clients use. The sat(std::string) convenience overload parses
+// formula-first and diverges from the REPL on some shapes (e.g. quantified
+// conjuncts), which is a separate pre-existing matter.
+static bool api_sat(const char* s) {
+	tref f = tau_api::get_formula_or_term(s);
+	if (!f) return false;
+	return tau_api::sat(f);
+}
+
+TEST_SUITE("component factoring") {
+	TEST_CASE("off by default: stock behavior") {
+		bdd_init<Bool>();
+		CHECK(api_sat("always ((o10[t] = 1 -> o11[t] = 1) && (o20[t] = 1 -> o21[t] = 1))"));
+	}
+	TEST_CASE("disjoint supports factor and stay sat") {
+		tau_api::set_component_factoring(true);
+		CHECK(api_sat("always ((o10[t] = 1 -> o11[t] = 1) && (o20[t] = 1 -> o21[t] = 1) && (o30[t] = 1 -> o31[t] = 1))"));
+		tau_api::set_component_factoring(false);
+	}
+	TEST_CASE("one dead component makes the whole unsat") {
+		tau_api::set_component_factoring(true);
+		CHECK(!api_sat("always ((o5[t] = 1) && (o5[t] = 0) && (o20[t] = 1 -> o21[t] = 1))"));
+		tau_api::set_component_factoring(false);
+	}
+	TEST_CASE("shared supports form one component: chain unsat detected") {
+		tau_api::set_component_factoring(true);
+		CHECK(!api_sat("always ((o1[t] = 1) && (o1[t] = 1 -> o2[t] = 1) && (o2[t] = 0))"));
+		tau_api::set_component_factoring(false);
+	}
+	TEST_CASE("quantifier above the conjunction suppresses the split") {
+		tau_api::set_component_factoring(true);
+		CHECK(api_sat("always ((all x (x = x)) && (o10[t] = 1 -> o11[t] = 1))"));
+		tau_api::set_component_factoring(false);
+	}
+	TEST_CASE("answers agree with stock on the same formulas") {
+		const char* fms[] = {
+			"always ((o10[t] = 1 -> o11[t] = 1) && (o20[t] = 1 -> o21[t] = 1))",
+			"always ((o5[t] = 1) && (o5[t] = 0) && (o20[t] = 1 -> o21[t] = 1))",
+			"always ((o1[t] = 1) && (o1[t] = 1 -> o2[t] = 1) && (o2[t] = 0))",
+		};
+		for (const char* fm : fms) {
+			bool stock = api_sat(fm);
+			tau_api::set_component_factoring(true);
+			bool factored = api_sat(fm);
+			tau_api::set_component_factoring(false);
+			CHECK(stock == factored);
+		}
+	}
+}


### PR DESCRIPTION
## What this does

`sat` on a top-level conjunction whose conjuncts split into connected
components over their variable supports currently pays an exponential cost
on satisfiable inputs (#72): the Boole decomposition copies every foreign
clause into both cofactors of each split, and memoization cannot help
because every partial assignment is a new formula. This PR adds an opt-in
pre-pass at the API sat entry (`api::realizable`, before `normalize_formula`):
if the root is a conjunction - optionally under a single top-level `always` -
and its conjuncts partition into more than one support component, each
component is decided independently and the results are conjoined.

Off by default. Opt in via `api::set_component_factoring(true)` (following
the runtime-parameter pattern of the split budget) or the `TAU_FACTOR_SAT`
environment variable (read once; convenient for CLI benchmarking).

## Soundness argument and guards

For the guarded fragment the argument is: models over disjoint stream sets
compose pointwise, and a winning strategy for each component composes to a
strategy for the whole - so the conjunction is satisfiable iff every
component is. The guards restrict the pass to exactly the case this argument
covers:

- the root must be a conjunction, optionally under ONE top-level `always`
  (a quantifier above the conjunction means the root is not a conjunction -
  no split, so quantifier scopes never span components);
- every conjunct must be free of nested temporal operators, `wff_ref`/`bf_ref`
  definition references, and non-bv `ba_constant`s (a tau-typed constant
  embeds a formula and could couple components invisibly);
- supports are variable NAMES, collected with the same depth discipline as
  `get_free_vars` (the offset variable `t` inside `o1[t]` is the shared
  timeline, not a support; bound-variable names are over-approximated into
  the support, which can only suppress a split, never fabricate one).

**The review point:** GSSOTC and its semantics are of course yours - what
is NOT backed by literature is our composition argument that this factoring
carries over to specs under `always`: the cited component-decomposition
results are propositional/BDD-level. If there is a semantic subtlety (e.g.
around initial segments or io-pairing) that breaks pointwise composition
even for disjoint stream sets, the guards need tightening. Everything else
falls through to the stock path unchanged.

## Prior art

Deciding the components of a support-partitioned conjunction independently
is the classic regime change in #SAT and symbolic model checking:
Bayardo & Pehoushek (AAAI 2000) decompose into connected components with
linear-time detection and report the overhead as negligible; Cachet
(Sang et al., SAT 2004/05) and sharpSAT (Thurley, SAT 2006) build production
counters on it; Burch/Clarke/Long (1991/94) show that for pairwise-disjoint
supports the partitioned representation is additive where the monolithic
one is multiplicative. The suggested-direction paragraph in #72 sketched
exactly this; the PR is that sketch made concrete and conservative.

## Numbers (the #73 fixtures, one 4-core box, ratios are the point)

| N disjoint | stock (main @ fa2d1d8b) | factored |
|---|---|---|
| 20 | 2.4 s | 0.20 s |
| 25 | 6.2 s | 0.25 s |
| 30 | 35.7 s | 0.30 s |
| 39 | >300 s (timeout) | 0.40 s |

The factored side grows linearly (~10 ms/clause). The chained-support
control (one component) is byte-identical in cost - the pass costs nothing
when it does not apply. Correctness probes agree with stock throughout,
including a ladder with exactly one dead component (answers F - the
conjunction of component verdicts is exercised, not bypassed).

## Tests

- `tests/integration/test_integration-satisfiability_factoring.cpp`:
  off-by-default behavior, disjoint split, dead component, shared-support
  chain (one component), quantifier-above-conjunction suppression, and a
  stock-vs-factored agreement sweep.
- Full suite on the same box: Release 328/328 and Debug 328/328, each
  both with the switch off and with it on (via the environment variable).

## Relation to feature/anti-prenexing-improvements

The rework in flight partitions clauses by eliminability component inside
the anti-prenex pass - this PR is complementary: it factors at the decision
entry, so the exponential case never reaches the normalizer at all. If the
branch ends up covering the disjoint-support case internally, this pass
still costs nothing (or can simply be dropped - it is one function and a
switch). Treat it as evidence plus an option, not a claim about where the
final fix should live.
