### PR TITLE
Opt-in per-block routing of interpreter quantifier blocks to the legacy anti-prenex path (addresses #76)

### DIFF
--- a/src/antiprenexing/antiprenexing.h
+++ b/src/antiprenexing/antiprenexing.h
@@ -38,6 +38,23 @@
 
 namespace idni::tau_lang {
 
+// Step formulas normalized by the interpreter pay the block pipeline's
+// expansion: on recurrent shapes `anti_prenex_block` can hand its own
+// fallback a formula orders of magnitude larger than the block it was given,
+// and that formula is what does not come back. Routing each quantifier block
+// to the legacy path instead keeps the pieces small, which matters because
+// the Boole decomposition is exponential in the atom count. Applies ONLY
+// while the interpreter normalizes, so one-off queries keep the stock
+// pipeline and its blasting-residue protection. Off by default; enable via
+// `api::set_run_block_bailout` or TAU_RUN_BLOCK_BAILOUT.
+inline bool run_block_bailout = false;
+inline thread_local int interpreter_normalization_depth = 0;
+struct interpreter_normalization_scope {
+	interpreter_normalization_scope() { ++interpreter_normalization_depth; }
+	~interpreter_normalization_scope() { --interpreter_normalization_depth; }
+};
+
+
 /**
  * @brief Apply the legacy, per-quantifier anti-prenex transformation.
  *

--- a/src/antiprenexing/antiprenexing.tmpl.h
+++ b/src/antiprenexing/antiprenexing.tmpl.h
@@ -1247,6 +1247,28 @@ tref process_quantifier_block(const quantifier_block<node>& blk,
 		return r;
 	};
 
+	// Hand exactly this block to the legacy anti-prenex rather than letting
+	// the decomposition pipeline work on it. Per block, not formula-wide -
+	// the legacy algorithm then sees many small formulas instead of a few
+	// large ones, and its Boole decomposition is exponential in the atom
+	// count. Interpreter-only: at depth 0 (one-off queries) the stock
+	// pipeline and its blasting-residue protection stay in charge.
+	{
+		static const bool env_enabled =
+			std::getenv("TAU_RUN_BLOCK_BAILOUT") != nullptr;
+		if ((run_block_bailout || env_enabled)
+			&& interpreter_normalization_depth > 0)
+		{
+			tref blk_fm = body;
+			for (auto it = block_vars.rbegin();
+				it != block_vars.rend(); ++it)
+				blk_fm = is_ex
+					? build_wff_ex<node>(*it, blk_fm, false)
+					: build_wff_all<node>(*it, blk_fm, false);
+			return wrap_skipped(anti_prenex<node>(blk_fm));
+		}
+	}
+
 	// Trivial Skolemization: if every variable in this block is trivially
 	// eliminable (see heuristics/trivial_skolem.h), skip BDD ordering,
 	// Boole decomposition, and predicate blasting below entirely. Only

--- a/src/api.h
+++ b/src/api.h
@@ -120,6 +120,12 @@ struct api {
 	// -----------------------------------------------------------------------
 	/** @brief Enable/disable character variable mode. */
 	static void set_charvar(bool state);
+	/** @brief Enable/disable routing quantifier blocks to the legacy
+	 *  anti-prenex path during interpreter normalization (run path only;
+	 *  one-off queries are unaffected). Applied per quantifier block.
+	 *  Off by default; the TAU_RUN_BLOCK_BAILOUT environment variable also
+	 *  enables it (read once). */
+	static void set_run_block_bailout(bool state);
 	/** @brief Enable/disable BV blasting. */
 	static void set_blasting(bool state);
 	/** @brief Enable/disable indenting in pretty-printed output. */

--- a/src/api.tmpl.h
+++ b/src/api.tmpl.h
@@ -48,6 +48,11 @@ void api<node>::set_blasting(bool blasting) {
 }
 
 template <NodeType node>
+void api<node>::set_run_block_bailout(bool state) {
+	run_block_bailout = state;
+}
+
+template <NodeType node>
 void api<node>::set_indenting(bool indenting) {
 	pretty_printer_indenting = indenting;
 }

--- a/src/interpreter.tmpl.h
+++ b/src/interpreter.tmpl.h
@@ -232,6 +232,9 @@ template<NodeType node>
 bool interpreter<node>::rebuild_outputs(
 	const subtree_map<node, size_t>& current_outputs)
 {
+	// Also interpreter normalization: without the scope these run at
+	// depth 0 and the interpreter-only routing above does not apply to them.
+	interpreter_normalization_scope _run_scope;
 	// Delete old streams
 	outputs.clear();
 	// open the corresponding streams for output and store them in streams
@@ -278,6 +281,7 @@ std::optional<interpreter<node>>
 		const io_context<node>& ctx)
 {
 	DBG(LOG_TRACE << "make_interpreter[spec]: " << LOG_FM_DUMP(spec) << "\n";)
+	interpreter_normalization_scope _run_scope;
 	// Find a satisfiable unbound continuation from spec
 	spec = normalizer<node>(spec);
 	// For each spec clause, we check if it is executable
@@ -653,6 +657,9 @@ void interpreter<node>::maybe_gc() {
 
 template <NodeType node>
 trefs interpreter<node>::get_ubt_ctn_at(int_t t) {
+	// Also interpreter normalization: without the scope these run at
+	// depth 0 and the interpreter-only routing above does not apply to them.
+	interpreter_normalization_scope _run_scope;
 	LOG_TRACE << "get_ubt_ctn_at begin \n";
 	LOG_TRACE << "get_ubt_ctn_at[t]: " << t << "\n";
 
@@ -844,6 +851,7 @@ tref interpreter<node>::get_executable_spec(
 
 template <NodeType node>
 void interpreter<node>::update(tref update) {
+	interpreter_normalization_scope _run_scope;
 	DBG(LOG_TRACE << "interpreter::update(update = \"" << LOG_FM(update) << "\")";)
 	// TODO: shift spec time according to new lookback from update
 	trefs io_vars = tau::get(update)
@@ -1026,6 +1034,7 @@ template <NodeType node>
 tref interpreter<node>::pointwise_revision(
 	tref spec, tref update, const int_t start_time)
 {
+	interpreter_normalization_scope _run_scope;
 	spec = normalizer<node>(spec);
 	update = normalizer<node>(update);
 	// If the update is T, nothing changes

--- a/src/normalizer.h
+++ b/src/normalizer.h
@@ -431,6 +431,12 @@ tref normalizer(tref fm);
 template <NodeType node, bool normalize_scopes = true>
 tref normalize_temporal_quantifiers(tref fm);
 
+// The opt-in routing of quantifier blocks to the legacy anti-prenex path
+// is declared in antiprenexing/antiprenexing.h (`run_block_bailout`,
+// `interpreter_normalization_depth`, `interpreter_normalization_scope`):
+// it is applied per quantifier block, so `process_quantifier_block` has to
+// see those. The interpreter marks its normalization phases with the scope.
+
 } // namespace idni::tau_lang
 
 #include "normalizer.tmpl.h"

--- a/src/normalizer.tmpl.h
+++ b/src/normalizer.tmpl.h
@@ -131,6 +131,12 @@ template <NodeType node>
 tref eliminate_bv_and_quantifiers(tref form) {
 	using tau = tree<node>;
 
+	// Note: the opt-in bail-out is applied in
+	// `process_quantifier_block` (antiprenexing.tmpl.h), per quantifier
+	// block, not here over the whole formula. Per block the legacy algorithm
+	// sees many small inputs instead of a few large ones, and its Boole
+	// decomposition is exponential in the atom count.
+
 	// Before anything blasts or decomposes: a foreign-typed sibling conjunct
 	// inside a bitvector quantifier's scope makes the whole scope fail
 	// `is_bv_solvable_formula`, so the solver shortcut below is skipped and

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -7,6 +7,8 @@ set(TESTS
 	bv_hooks
 	bf_normalization
 	interpreter
+	interpreter_block_bailout
+	interpreter_block_bailout_tau
 	nso_rr_execution
 	nso_rr_fixed_point
 	nso_rr_partial_eval

--- a/tests/integration/test_integration-interpreter_block_bailout.cpp
+++ b/tests/integration/test_integration-interpreter_block_bailout.cpp
@@ -1,0 +1,71 @@
+// To view the license please visit https://github.com/IDNI/tau-lang/blob/main/LICENSE.md
+
+// Per-block bail-out to the legacy anti-prenex during interpreter
+// normalization (run path).
+// The bail-out changes ROUTING, not semantics: with the switch on, the same
+// spec must produce the same outputs as the stock pipeline. The sample is the
+// nested-conditionals shape from the mixed tau/bv regression test.
+// A spec with no bv content at all is covered by its own test binary
+// (test_integration-interpreter_block_bailout_tau) -- one spec family per
+// process, so neither measurement inherits the other's interpreter state.
+
+#include "test_integration-interpreter_helper.h"
+
+#include "api.h"
+
+using tau_api = api<node_t>;
+
+static const char* mixed_sample =
+	"o0seal[0]:tau = 1 && o0law[0]:tau = 1 && "
+	"( (i2[t]:bv[8] = { #x01 }:bv[8]) "
+	"  ? ( (o0seal[t]:tau = o0law[t-1]:tau) "
+	"      && (o0law[t]:tau = o0law[t-1]:tau) "
+	"      && (o0res[t]:bv[8] = { #x05 }:bv[8]) ) "
+	"  : ( (o0seal[t]:tau = o0seal[t-1]:tau) && "
+	"      ( ((o0law[t-1]:tau & i1[t]:tau) != 0) "
+	"        ? ( (o0law[t]:tau = o0law[t-1]:tau & i1[t]:tau) "
+	"            && (o0res[t]:bv[8] = { #x09 }:bv[8]) ) "
+	"        : ( (o0law[t]:tau = o0law[t-1]:tau) "
+	"            && (o0res[t]:bv[8] = { #x08 }:bv[8]) ) ) ) ).";
+
+static std::optional<assignment<node_t>> run_mixed() {
+	io_context<node_t> ctx;
+	strings i1_values = { "T", "T" };
+	strings i2_values = { "{ #x01 }:bv[8]", "{ #x01 }:bv[8]" };
+	ctx.add_input("i1", tau_type_id<node_t>(),
+		std::make_shared<vector_input_stream>(i1_values));
+	ctx.add_input("i2", bv_type_id<node_t>(8),
+		std::make_shared<vector_input_stream>(i2_values));
+	return run_test(mixed_sample, ctx, 1);
+}
+
+TEST_SUITE("interpreter block bail-out") {
+	TEST_CASE("off by default: stock routing works") {
+		bdd_init<Bool>();
+		auto memory = run_mixed();
+		REQUIRE( memory.has_value() );
+		CHECK ( !memory.value().empty() );
+	}
+	TEST_CASE("routing is per block: a tau-only block keeps its own route") {
+		// The switch is applied per quantifier block, so a spec whose bv
+		// content sits in one block must still agree with stock routing.
+		auto stock = run_mixed();
+		REQUIRE( stock.has_value() );
+		tau_api::set_run_block_bailout(true);
+		auto routed = run_mixed();
+		tau_api::set_run_block_bailout(false);
+		REQUIRE( routed.has_value() );
+		CHECK ( stock.value() == routed.value() );
+	}
+	TEST_CASE("bail-out routing produces the same outputs") {
+		auto stock = run_mixed();
+		REQUIRE( stock.has_value() );
+		tau_api::set_run_block_bailout(true);
+		auto bailed = run_mixed();
+		tau_api::set_run_block_bailout(false);
+		REQUIRE( bailed.has_value() );
+		// hash-consed trees: equal content means equal trefs, so the
+		// assignments compare directly
+		CHECK ( stock.value() == bailed.value() );
+	}
+}

--- a/tests/integration/test_integration-interpreter_block_bailout_tau.cpp
+++ b/tests/integration/test_integration-interpreter_block_bailout_tau.cpp
@@ -1,0 +1,50 @@
+// To view the license please visit https://github.com/IDNI/tau-lang/blob/main/LICENSE.md
+
+// Per-block bail-out, applied to a spec with NO bv content.
+// The routing predicate is the interpreter context alone, not what the block
+// contains, so this shape is routed as well and must keep its outputs.
+// Own binary on purpose: this spec family and the mixed one from
+// test_integration-interpreter_block_bailout are kept in separate processes.
+
+#include "test_integration-interpreter_helper.h"
+
+#include "api.h"
+
+using tau_api = api<node_t>;
+
+static const char* tau_only_sample =
+	"o0seal[0]:tau = 1 && o0law[0]:tau = 1 && "
+	"( (i2[t]:tau != 0) "
+	"  ? ( (o0seal[t]:tau = o0law[t-1]:tau) "
+	"      && (o0law[t]:tau = o0law[t-1]:tau) ) "
+	"  : ( (o0seal[t]:tau = o0seal[t-1]:tau) "
+	"      && (o0law[t]:tau = o0law[t-1]:tau & i1[t]:tau) ) ).";
+
+static std::optional<assignment<node_t>> run_tau_only() {
+	io_context<node_t> ctx;
+	strings i1_values = { "T", "T" };
+	strings i2_values = { "F", "F" };
+	ctx.add_input("i1", tau_type_id<node_t>(),
+		std::make_shared<vector_input_stream>(i1_values));
+	ctx.add_input("i2", tau_type_id<node_t>(),
+		std::make_shared<vector_input_stream>(i2_values));
+	return run_test(tau_only_sample, ctx, 1);
+}
+
+TEST_SUITE("interpreter block bail-out, no bv content") {
+	TEST_CASE("off by default: stock routing works") {
+		bdd_init<Bool>();
+		auto memory = run_tau_only();
+		REQUIRE( memory.has_value() );
+		CHECK ( !memory.value().empty() );
+	}
+	TEST_CASE("a spec without bv content is routed too, and agrees") {
+		auto stock = run_tau_only();
+		REQUIRE( stock.has_value() );
+		tau_api::set_run_block_bailout(true);
+		auto routed = run_tau_only();
+		tau_api::set_run_block_bailout(false);
+		REQUIRE( routed.has_value() );
+		CHECK ( stock.value() == routed.value() );
+	}
+}


### PR DESCRIPTION
Opt-in, off by default. During interpreter normalization, hand each quantifier
block to the legacy `anti_prenex` instead of to the block pipeline. One-off
queries are untouched.

This replaces the previous state of this branch, which routed only blocks
containing bv-typed content. What follows is why that predicate is gone.

## What the block pipeline passes to the fallback

`resolve_ex_block` runs `anti_prenex_block` and `resolve_quantifiers2`, then
falls back to `anti_prenex` if live quantifiers remain. Measuring both sides of
that boundary, on the bitvector-free reproducer from #76 and on the same spec
with the meet guard removed (which finishes in 0.32 s):

| block | reproducer | meet guard removed |
|---|---|---|
| 1 | 1,367 -> 123,166 | 857 -> 9,482 |
| 2 | 2,166 -> 2,106 | 2,033 -> 2,039 |
| 3 | 3,838 -> 2,171 | 3,621 -> 2,104 |
| 4 | **23,369 -> 5,481,813** | 7,610 -> 132,984 |

Characters of the printed formula; every block here has two quantified
variables.

The fourth call is the one that does not return: a counter in the legacy loop
runs from 2,000 to 164,000 iterations while the call count and the total input
length stay unchanged. Its input is not the block, but what the pipeline made of
the block - about 234 times larger. Tripling what goes in multiplies what comes
out by 41.

So this switch does not decompose better; it routes before the expansion, so the
large formula is never built. And the bv test was not the property that matters:
it selected the blocks where the cost first showed up on the specs we happened
to be carrying. `interpreter_normalization_depth` already answers what the
routing needs to know, and dropping the test removes the per-block `find_top`
scan.

Those two columns come from a tree carrying about ten lines of instrumentation
at that boundary, on base `9a3cc35e` plus our two opt-in patches - glad to share
it. Everything below is this branch at `fd137e86`.

## Numbers

Wall clock for the whole run, switch off against on, split so the change of
predicate is not credited with more than it did.

Specs with no bv content - what the previous predicate left on the stock route:

| | off | on |
|---|---|---|
| bitvector-free reproducer (#76) | no output in 200 s | **0.20 s** |
| same shape, two stream pairs (spec on #76) | no output in 200 s | **24.7 s** |
| same shape, meet guard removed | 0.32 s | 0.14 s |

Mixed `:tau`/bv - already routed before this change, listed so the table is not
read as a gain of the new predicate:

| | off | on |
|---|---|---|
| cross-stream + meet guard | 63.7 s | 2.06 s |
| cross-stream, no meet guard | 1.39 s | 0.89 s |

The tau-nomic tutorial series, 11 files via the CLI: **11/11 in 66 s at 168 MB**.
Our replay harness completes at 146 MB peak against a host built from this
branch alone; with the switch off the same host does not become ready inside the
same budget.

Outputs agree: we diffed nine reproducers and the interpreter's assignments are
identical in all of them. On some, the echoed normalized formula differs in the
order of its top-level conjuncts - the `build_bf_and` point from #76, not a
semantic difference.

## Changes and tests

Renamed, since the name no longer describes the mechanism:
`api::set_run_bv_bailout` -> `api::set_run_block_bailout`, `TAU_RUN_BV_BAILOUT`
-> `TAU_RUN_BLOCK_BAILOUT`. We said on the previous update that the knob would
keep working unchanged; this breaks that.

`test_integration-interpreter_block_bailout` (3 cases) and the `_tau` variant
(2 cases) check one contract: routing changes, semantics do not. They are parity
tests and would pass without this change as well - routing is semantically
neutral, so there is no in-process observable other than timing, which we did
not want in an assertion. The evidence that the routing does something is the
table above, not the suite. The bv-free spec has its own binary because running
both spec families in one process makes the second very slow regardless of this
switch - we checked with the routing compiled out entirely.

Suite, Release, one build and two `ctest` runs: **330/330 with the switch off
(109 s), 330/330 with it on (105 s)**. 330 is your 328 plus the two binaries
above. The switch-on run is the one that says something: the routing is then
live for every interpreter test, not only ours. No Debug run this time.

## Limits

- This routes to the legacy `anti_prenex`, and `c297108b` removes that algorithm
  on `feature/anti-prenexing-improvements`. We think that removal is right:
  carrying two anti-prenex implementations is a cost of its own, and
  consolidating on the block pipeline is what lets an improvement there reach
  every caller at once. So this patch leans on a path you are deliberately
  retiring and is not an argument for keeping it. What we would keep either way
  is the measurement, which is about `anti_prenex_block`.
- Interpreter-only: the guard cannot fire at depth 0. That condition is
  unchanged from the previous version; we measured a one-off query matrix
  against *that* version, on and off, and saw -11 % to +9 % in both directions
  with no pattern. We have not repeated it here.
- The routing is unconditional inside the interpreter, so the block pipeline
  does not run there at all. Nothing we measured needs it there - eleven
  reproducers and the tutorial series - but that is our scale, not a proof.
- Single runs. #80 is why we would put error bars on any single run of this
  class; it is independent of this PR and predates it.

Environment: Linux x86-64, 4 cores.
