### PR TITLE
Fix AppleClang build errors and cvc5 teardown

### DIFF
--- a/src/ba_constants.h
+++ b/src/ba_constants.h
@@ -12,6 +12,9 @@
 #ifndef __IDNI__TAU__BA_CONSTANTS_H__
 #define __IDNI__TAU__BA_CONSTANTS_H__
 
+#include <cstdlib>
+#include <stdexcept>
+
 #include "tau_tree.h"
 
 namespace idni::tau_lang {

--- a/src/ba_constants.tmpl.h
+++ b/src/ba_constants.tmpl.h
@@ -13,6 +13,19 @@ namespace idni::tau_lang {
 
 template <NodeType node>
 tref ba_constants<node>::get(const constant& constant, size_t type_id) {
+	// cvc5 requires every Term to be destroyed before its process-wide node
+	// manager is torn down.  The pool's inline-static destructor does not have
+	// a reliable order relative to that manager across executables and shared
+	// libraries, so empty the pool through a late-registered exit handler first.
+	// The normal static destructors then only see empty containers.
+	static const bool cleanup_registered = [] {
+		if (std::atexit([] { ba_constants<node>::cleanup(); }) != 0)
+			throw std::runtime_error(
+				"ba_constants: unable to register process cleanup");
+		return true;
+	}();
+	(void)cleanup_registered;
+
 	LOG_TRACE << "-- get(constant, type_id): "
 		<< LOG_BA(constant) << ", " << LOG_BA_TYPE(type_id);
 	// LOG_TRACE << dump_to_str();

--- a/src/boolean_algebras/bdds/babdd.h
+++ b/src/boolean_algebras/bdds/babdd.h
@@ -388,7 +388,7 @@ struct bdd : std::variant<bdd_node<bdd_reference<o.has_varshift(), o.has_inv_ord
 		if constexpr (o.has_varshift()) {
 			cache.emplace(bdd_ref::to_shift_node(x, x.shift),
 				      bdd_ref::to_shift_node(r, x.shift));
-		} else cache.emplace(move(x), move(r));
+		} else cache.emplace(std::move(x), std::move(r));
 	}
 
 	static void update_cache(bdd_ref x, uint_t v, bdd_ref r, auto& cache) {
@@ -403,7 +403,8 @@ struct bdd : std::variant<bdd_node<bdd_reference<o.has_varshift(), o.has_inv_ord
 					      bdd_ref::to_shift_node(x, x.shift),
 					      v - (x.shift - 1)},
 				      bdd_ref::to_shift_node(r, x.shift));
-		} else cache.emplace(std::pair<bdd_ref, uint_t>{move(x), v}, move(r));
+		} else cache.emplace(
+			std::pair<bdd_ref, uint_t>{std::move(x), v}, std::move(r));
 	}
 
 	static void update_cache(bdd_ref x, bdd_ref y, bdd_ref r, auto &cache) {
@@ -420,7 +421,9 @@ struct bdd : std::variant<bdd_node<bdd_reference<o.has_varshift(), o.has_inv_ord
 					      bdd_ref::to_shift_node(x, d),
 					      bdd_ref::to_shift_node(y, d)},
 				      bdd_ref::to_shift_node(r, d));
-		} else cache.emplace(std::array<bdd_ref,2>{move(x),move(y)},move(r));
+		} else cache.emplace(
+			std::array<bdd_ref, 2>{std::move(x), std::move(y)},
+			std::move(r));
 	}
 
 	static void mk_order_canonical(bdd_ref& x, bdd_ref& y) {
@@ -970,7 +973,7 @@ struct bdd<Bool, o> : bdd_node<bdd_reference<o.has_varshift(), o.has_inv_order()
 		if constexpr (o.has_varshift()) {
 			cache.emplace(bdd_ref::to_shift_node(x, x.shift),
 				      bdd_ref::to_shift_node(r, x.shift));
-		} else cache.emplace(move(x), move(r));
+		} else cache.emplace(std::move(x), std::move(r));
 	}
 
 	static void update_cache(bdd_ref x, uint_t v, bdd_ref r, auto& cache) {
@@ -985,7 +988,8 @@ struct bdd<Bool, o> : bdd_node<bdd_reference<o.has_varshift(), o.has_inv_order()
 					      bdd_ref::to_shift_node(x, x.shift),
 					      v - (x.shift - 1)},
 				      bdd_ref::to_shift_node(r, x.shift));
-		} else cache.emplace(std::pair<bdd_ref, uint_t>{move(x), v}, move(r));
+		} else cache.emplace(
+			std::pair<bdd_ref, uint_t>{std::move(x), v}, std::move(r));
 	}
 
 	static void update_cache(bdd_ref x, bdd_ref y, bdd_ref r, auto &cache) {
@@ -1002,7 +1006,9 @@ struct bdd<Bool, o> : bdd_node<bdd_reference<o.has_varshift(), o.has_inv_order()
 					      bdd_ref::to_shift_node(x, d),
 					      bdd_ref::to_shift_node(y, d)},
 				      bdd_ref::to_shift_node(r, d));
-		} else cache.emplace(std::array<bdd_ref,2>{move(x),move(y)},move(r));
+		} else cache.emplace(
+			std::array<bdd_ref, 2>{std::move(x), std::move(y)},
+			std::move(r));
 	}
 
 	static void mk_order_canonical(bdd_ref& x, bdd_ref& y) {
@@ -1175,7 +1181,7 @@ struct bdd<Bool, o> : bdd_node<bdd_reference<o.has_varshift(), o.has_inv_order()
 				if (hasbc(x, l[n], am_cmp)) l.erase(l.begin() + n);
 				else ++n;
 			h.shrink_to_fit(), l.shrink_to_fit(), x.shrink_to_fit();
-			bdd_ref r = bdd_and_many(move(x));
+			bdd_ref r = bdd_and_many(std::move(x));
 			if (r == F) return res = F, 1;
 			if (r != T) {
 				if (!hasbc(h, r, am_cmp)) h.push_back(r), am_sort(h);
@@ -1211,12 +1217,12 @@ struct bdd<Bool, o> : bdd_node<bdd_reference<o.has_varshift(), o.has_inv_order()
 		uint_t m = 0;
 		std::vector<bdd_ref> vh, vl;
 		switch (bdd_and_many_iter(v, vh, vl, res, m)) {
-			case 0: l = bdd_and_many(move(vl)),
-					h = bdd_and_many(move(vh));
+			case 0: l = bdd_and_many(std::move(vl)),
+					h = bdd_and_many(std::move(vh));
 				break;
 			case 1: return and_many_memo.emplace(v, res), res;
-			case 2: h = bdd_and_many(move(vh)), l = F; break;
-			case 3: h = F, l = bdd_and_many(move(vl)); break;
+			case 2: h = bdd_and_many(std::move(vh)), l = F; break;
+			case 3: h = F, l = bdd_and_many(std::move(vl)); break;
 			default: { DBG(assert(false)); }
 		}
 		return and_many_memo.emplace(v, bdd::add(m, h, l)).first->second;

--- a/src/tau_bdd.tmpl.h
+++ b/src/tau_bdd.tmpl.h
@@ -695,7 +695,7 @@ size_t tau_term_bdd<node>::bdd_and_many_iter(const refs& v,
 			if (hasbc(x, l[n], am_cmp)) l.erase(l.begin() + n);
 			else ++n;
 		h.shrink_to_fit(), l.shrink_to_fit(), x.shrink_to_fit();
-		ref r = bdd_and_many(move(x), o);
+		ref r = bdd_and_many(std::move(x), o);
 		if (r == F) return res = F, 1;
 		if (r != T) {
 			if (!hasbc(h, r, am_cmp)) h.push_back(r), am_sort(h);
@@ -754,8 +754,8 @@ tau_term_bdd<node>::ref tau_term_bdd<node>::bdd_and_many(refs v, const order& o)
 	tref m = nullptr;
 	refs vh, vl;
 	switch (bdd_and_many_iter(v, vh, vl, res, m, o)) {
-		case 0: l = bdd_and_many(move(vl), o),
-			h = bdd_and_many(move(vh), o);
+		case 0: l = bdd_and_many(std::move(vl), o),
+			h = bdd_and_many(std::move(vh), o);
 			break;
 		case 1: {
 #ifdef TAU_CACHE
@@ -763,8 +763,8 @@ tau_term_bdd<node>::ref tau_term_bdd<node>::bdd_and_many(refs v, const order& o)
 #endif
 			return res;
 		}
-		case 2: h = bdd_and_many(move(vh), o), l = F; break;
-		case 3: h = F, l = bdd_and_many(move(vl), o); break;
+		case 2: h = bdd_and_many(std::move(vh), o), l = F; break;
+		case 3: h = F, l = bdd_and_many(std::move(vl), o); break;
 		default: { DBG(assert(false)); return ref(); }
 	}
 #ifdef TAU_CACHE
@@ -881,8 +881,8 @@ template<NodeType node>
 tau_term_bdd_handle<node>::term_handle tau_term_bdd_handle<node>::
 convert_to_handle(tref tau_node) {
 	auto it = U.find(tau_node);
-	DBG(assert(it != U.end));
-	if (it != U.end) return it->second;
+	DBG(assert(it != U.end()));
+	if (it != U.end()) return it->second;
 	else return term_handle(tbdd::T);
 }
 


### PR DESCRIPTION
## Summary

Fix the remaining AppleClang source errors and ensure pooled cvc5 Terms are destroyed before cvc5 global teardown on macOS arm64.

Tracks #78. Depends on IDNI/parser#16. The parser submodule pointer is intentionally not advanced here; it can be updated after that PR merges.

## Changes

- qualify move calls as std::move in the BDD implementations
- fix the U.end() iterator comparisons in tau_term_bdd_handle
- register ba_constants cleanup on first pool use so cvc5 Terms are released before process-wide cvc5 teardown
- add the direct standard-library includes required by that cleanup path

## Root cause

The BA constant pool stores cvc5::Term values in inline-static containers. On macOS their destructors could run after cvc5 had already torn down its process-wide node manager. The resulting exit-time stack passed through NodeValue::markForDeletion, Term::~Term, vector::~vector, and __cxa_finalize_ranges.

The late-registered exit handler empties the pool while cvc5 is still live. Normal static destruction then sees empty containers.

## Verification

On macOS arm64 with AppleClang 17.0.0 and cvc5 1.3.1:

- Debug build through ./dev: all 252 targets built
- Debug tests: 319/327 passed; zero crashes or aborts
- Release build through ./dev: all 252 targets built
- Release tests: 323/327 passed; zero crashes or aborts
- native executable: Tau Language Framework version 0.7.0-alpha (9a3cc35e)
- Python 3.14.3 nanobind module: built, imported, and exited cleanly

The four Release failures are pre-existing portable canonicalization assertions: exact conjunct/equality ordering, BDD string ordering, and one antiprenexing intermediate equation-count expectation. They are listed in #78 and are separate from the build and lifetime fixes.