### PR TITLE
Hash `rr<node>` by tree content instead of handle address

### DIFF
--- a/src/rr.tmpl.h
+++ b/src/rr.tmpl.h
@@ -82,7 +82,21 @@ constexpr auto rr<node>::operator!=(const rr<node>& that) const {
 template<idni::tau_lang::NodeType node>
 std::size_t std::hash<idni::tau_lang::rr<node>>::operator()(
 	const idni::tau_lang::rr<node>& rr) const noexcept {
-	size_t seed = 0;
-	idni::hash_combine(seed, rr.rec_relations, rr.main);
+	// `htref` is `std::shared_ptr<htree>`, so `std::hash<htref>` hashes the
+	// address of the handle rather than the tree it denotes, while
+	// `rr::operator==` compares tree content (see `compare_trees` above).
+	// Structurally equal trees then receive different hashes, hash consing
+	// stops merging them, and node identity - together with every decision
+	// taken on it - depends on the heap layout of the individual run.
+	// Both members are affected: `rec_relations` is a
+	// `vector<pair<htref, htref>>`. The tree nodes already carry a
+	// content-derived hash; use it.
+	auto h = [](const idni::htref& r) noexcept -> size_t {
+		return r ? idni::hash_tref<node>{}(r->get()) : 0;
+	};
+	size_t seed = rr.rec_relations.size();   // mirrors std::hash<vector<T>>
+	for (const auto& [head, body] : rr.rec_relations)
+		idni::hash_combine(seed, h(head), h(body));
+	idni::hash_combine(seed, h(rr.main));
 	return seed;
 }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TESTS
 	nso_rr
 	product_ba
 	ref_variables_resolver
+	rr_hash
 	sbf_ba_parsing
 	sbf_ba_splitter
 	tau_ba

--- a/tests/unit/test_rr_hash.cpp
+++ b/tests/unit/test_rr_hash.cpp
@@ -1,0 +1,102 @@
+// To view the license please visit https://github.com/IDNI/tau-lang/blob/main/LICENSE.md
+
+// `std::hash<rr<node>>` must agree with `rr::operator==`, which compares tree
+// content through `compare_trees`. Both members are built from `htref` =
+// `std::shared_ptr<htree>`, and with no `std::hash<htref>` in sight the
+// `shared_ptr` specialization applies and hashes the stored address.
+//
+// The address is not a property of the tree. `bintree<T>::geth` caches the
+// handle in a `weak_ptr`, so asking twice returns the same `htree` only while
+// someone still holds it; once the last owner is gone, the next call builds a
+// fresh `htree` for the same `tref` — same tree, new address. The cases below
+// reconstruct exactly that.
+//
+// Two notes for anyone editing this file:
+//   - the probe tree must be one nothing else retains. `tau::_T()` is held
+//     permanently elsewhere (`use_count` 3 in a bare test binary), so its
+//     handle never expires and the defect cannot show on it.
+//   - the ballast has to stay allocated. Releasing it lets the allocator hand
+//     the very same address back, and the test then passes with the defect
+//     present.
+
+#include "test_init.h"
+#include "test_tau_helpers.h"
+
+using rr_t = rr<node_t>;
+using rr_hash = std::hash<rr_t>;
+
+namespace {
+
+// A tree nobody else holds a handle to.
+tref probe_tree(const char* name) {
+	return tau::build_bf_eq_0(
+		build_bf_variable<node_t>(name, tau_type_id<node_t>()));
+}
+
+// Occupy the block the released `htree` left behind, and keep it occupied.
+std::vector<std::unique_ptr<char[]>> g_ballast;
+
+void occupy_freed_blocks() {
+	for (size_t sz = 8; sz <= 128; sz += 8)
+		for (int i = 0; i < 32; ++i)
+			g_ballast.push_back(std::make_unique<char[]>(sz));
+}
+
+size_t hash_of_fresh_handle(tref x) {
+	return rr_hash{}(rr_t(tau::geth(x)));
+}
+
+} // namespace
+
+TEST_SUITE("configuration") {
+	TEST_CASE("bdd_init") { bdd_init<Bool>(); }
+}
+
+TEST_SUITE("rr hash agrees with rr equality") {
+
+	TEST_CASE("equal content hashes equally across handle lifetimes") {
+		tref x = probe_tree("rr_hash_probe_a");
+		size_t first = hash_of_fresh_handle(x);   // handle dies here
+		occupy_freed_blocks();
+		size_t second = hash_of_fresh_handle(x);  // fresh htree, same tree
+		CHECK( first == second );
+	}
+
+	TEST_CASE("the same holds with non-empty rec_relations") {
+		tref head = probe_tree("rr_hash_probe_head");
+		tref body = probe_tree("rr_hash_probe_body");
+		tref main = probe_tree("rr_hash_probe_main");
+
+		size_t first;
+		{
+			rewriter::rules rules;
+			rules.emplace_back(tau::geth(head), tau::geth(body));
+			first = rr_hash{}(rr_t(rules, tau::geth(main)));
+		}
+		occupy_freed_blocks();
+
+		rewriter::rules rules;
+		rules.emplace_back(tau::geth(head), tau::geth(body));
+		rr_t b(rules, tau::geth(main));
+
+		CHECK( first == rr_hash{}(b) );
+	}
+
+	TEST_CASE("different content still hashes differently") {
+		rr_t a(tau::geth(probe_tree("rr_hash_probe_x")));
+		rr_t b(tau::geth(probe_tree("rr_hash_probe_y")));
+		CHECK_FALSE( a == b );
+		CHECK( rr_hash{}(a) != rr_hash{}(b) );
+	}
+
+	TEST_CASE("rec_relations take part in the hash") {
+		tref main = probe_tree("rr_hash_probe_main2");
+		rewriter::rules rules;
+		rules.emplace_back(tau::geth(probe_tree("rr_hash_probe_h2")),
+				   tau::geth(probe_tree("rr_hash_probe_b2")));
+		rr_t with(rules, tau::geth(main));
+		rr_t without(tau::geth(main));
+		CHECK_FALSE( with == without );
+		CHECK( rr_hash{}(with) != rr_hash{}(without) );
+	}
+}


### PR DESCRIPTION
Closes #80.

`std::hash<rr<node>>` hashes its two members — both built from
`htref` = `std::shared_ptr<htree>` — through `std::hash<shared_ptr>`, i.e. by
address, while `rr::operator==` compares tree content. The issue has the
analysis; this is the change.

## The change

Use the content-derived hash the tree nodes already carry, through your own
`hash_tref<T>` helper (`utility/tree.tmpl.h:368`, returning
`bintree<T>::get(r).hash`) — the same helper `src/tau_bdd.tmpl.h` already
uses in three places. `seed = rec_relations.size()` mirrors your
`std::hash<vector<T>>`.

```cpp
auto h = [](const idni::htref& r) noexcept -> size_t {
	return r ? idni::hash_tref<node>{}(r->get()) : 0;
};
size_t seed = rr.rec_relations.size();
for (const auto& [head, body] : rr.rec_relations)
	idni::hash_combine(seed, h(head), h(body));
idni::hash_combine(seed, h(rr.main));
```

One function in one file. It is unconditional rather than opt-in because
there is nothing to opt into: the hash has to agree with the equality it is
paired with, and there is no tuning knob here.

## Tests

`tests/unit/test_rr_hash.cpp`. The cases assert the **invariant** rather than
the symptom — run-to-run drift would need a second process, but the invariant
does not, because `bintree<T>::geth` caches the handle in a `weak_ptr`:

```cpp
size_t first  = hash_of_fresh_handle(x);   // the handle dies at scope exit
occupy_freed_blocks();                     // so a fresh htree lands elsewhere
size_t second = hash_of_fresh_handle(x);   // fresh htree, same tree
CHECK( first == second );
```

Verified both ways on this branch's base: with `src/rr.tmpl.h` reverted the
file reports **2 of its 5 cases failing**; with the change in place, **5 of
5 passing**. A test that stays green either way would prove nothing, and an
earlier version of this one did exactly that — two details turned out to
matter, and both are noted in the file so they do not get refactored away:

- The probe tree has to be one nothing else retains. `tau::_T()` is held
  permanently elsewhere (`use_count` 3 in a bare test binary), so its handle
  never expires and the defect cannot surface on it.
- The ballast has to stay allocated. Released, the allocator hands back the
  very same address and the hashes agree by accident.

The remaining cases cover the same with **non-empty `rec_relations`** — the
half no `.tau` spec on the run path seems to exercise, which is why we wanted
it under test — that unequal content still hashes unequally, and that
`rec_relations` take part in the hash at all.

## Suite

**329/329 passing, 0 failures** (Release). The change is unconditional, so
every one of those tests exercises it — which matters here, because altering
hash *values* changes iteration orders over hash containers, and that is the
failure mode worth looking for.

To be precise about the scope: that run was on a working tree carrying this
change together with two other opt-in patches of ours, based on `9a3cc35e`
rather than on this branch's base, and Debug was not run. The new unit test
above was not part of it; it was built and run separately, both with and
without the change. Happy to run the suite on this branch in isolation before
merging if you would like that.

## Effect

| | before | after |
|---|---|---|
| distinct outputs over 10 runs (timing lines excluded) | 1 | 1 |
| distinct internal counter signatures, 10 runs | 5 | **1** |
| distinct step-1 node hashes, 8 runs | 8 | **1** |

Measured with `setarch -R`, an empty environment, single threaded, parser
pinned.

This is not a performance change: the value the effort settles on is the
cheaper one on one probe and the more expensive one on another. What it buys
is that measurements become comparable at all.

## What it does not do

It does not touch the cost level of anything, and it does not address the
interpreter run-path costs discussed in #76 — those are independent, and the
routing side of them is in #77.