### PR TITLE
Opt-in: check the fixpoint condition per top-level conjunct (addresses #82)

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -120,6 +120,11 @@ struct api {
 	// -----------------------------------------------------------------------
 	/** @brief Enable/disable character variable mode. */
 	static void set_charvar(bool state);
+	/** @brief Check the fixpoint condition per top-level conjunct.
+	 *  Semantically neutral (implication distributes over a conjunction on
+	 *  the right); off by default. The TAU_QE_FIXSPLIT environment variable
+	 *  also enables it (read once). */
+	static void set_fixpoint_conjunct_split(bool state);
 	/** @brief Enable/disable BV blasting. */
 	static void set_blasting(bool state);
 	/** @brief Enable/disable indenting in pretty-printed output. */

--- a/src/api.tmpl.h
+++ b/src/api.tmpl.h
@@ -48,6 +48,11 @@ void api<node>::set_blasting(bool blasting) {
 }
 
 template <NodeType node>
+void api<node>::set_fixpoint_conjunct_split(bool state) {
+	fixpoint_conjunct_split = state;
+}
+
+template <NodeType node>
 void api<node>::set_indenting(bool indenting) {
 	pretty_printer_indenting = indenting;
 }

--- a/src/satisfiability.h
+++ b/src/satisfiability.h
@@ -18,6 +18,13 @@
 
 namespace idni::tau_lang {
 
+/// Check the fixpoint condition per top-level conjunct instead of once over the
+/// whole right-hand side. Semantically neutral: implication distributes over a
+/// conjunction on the right. Off by default; `api::set_fixpoint_conjunct_split`
+/// or the TAU_QE_FIXSPLIT environment variable enable it.
+inline bool fixpoint_conjunct_split = false;
+
+
 /**
  * @brief Instantiate @p original_fm for IO variables at @p time_point.
  * @tparam node Tree node type.

--- a/src/satisfiability.tmpl.h
+++ b/src/satisfiability.tmpl.h
@@ -572,6 +572,43 @@ tref get_uninterpreted_constants_constraints(tref fm, trefs& io_vars, const int_
 
 /**
  * @internal
+ * @brief Fixpoint test `prev |= next`, checked per top-level conjunct.
+ *
+ * Implication distributes over a conjunction on the right:
+ *     phi |= psi_1 & ... & psi_n   <=>   for all i. phi |= psi_i
+ * This is an elementary equivalence and assumes nothing about the conjuncts.
+ * It matters because `is_nso_impl` closes the implication over its free
+ * variables and normalizes it, so the whole right-hand side reaches the Boole
+ * decomposition in one piece -- and that step is exponential in the atom count.
+ * Splitting replaces one decomposition over all atoms by n decompositions over
+ * a fraction of them each. Returns at the first conjunct that is not implied.
+ *
+ * Opt-in via `api::set_fixpoint_conjunct_split` or TAU_QE_FIXSPLIT; with the
+ * switch off, or when the right-hand side
+ * is not a conjunction, this is exactly the original single call.
+ * @endinternal
+ */
+template <NodeType node>
+bool fixpoint_reached(tref prev, tref next) {
+	using tau = tree<node>;
+	static const bool env_enabled = std::getenv("TAU_QE_FIXSPLIT") != nullptr;
+	if (!(fixpoint_conjunct_split || env_enabled))
+		return is_nso_impl<node>(prev, next);
+	trefs cs;
+	std::function<void(tref)> collect = [&](tref n) {
+		if (tau::get(n).child_is(tau::wff_and)) {
+			collect(tau::get(n)[0].first());
+			collect(tau::get(n)[0].second());
+		} else cs.push_back(n);
+	};
+	collect(next);
+	if (cs.size() < 2) return is_nso_impl<node>(prev, next);
+	for (tref c : cs) if (!is_nso_impl<node>(prev, c)) return false;
+	return true;
+}
+
+/**
+ * @internal
  * @brief Compute the unbounded (infinite-horizon) continuation of an
  * `always`-part `base_fm` by repeatedly unrolling one more time step and
  * checking for a fixpoint (`is_nso_impl(phi_prev, phi)`), i.e. the point at
@@ -633,7 +670,7 @@ std::pair<tref, int_t> find_fixpoint_phi(tref base_fm, tref ctn_initials,
 	// tests/integration/test_integration-solver.cpp reach single digits), so
 	// this leaves a very wide margin while remaining finite.
 	constexpr int_t max_fixpoint_steps = 500;
-	while (step_num < lookback || !is_nso_impl<node>(phi_prev, phi)){
+	while (step_num < lookback || !fixpoint_reached<node>(phi_prev, phi)){
 		if (step_num >= max_fixpoint_steps) {
 			LOG_ERROR << "find_fixpoint_phi: exceeded " << max_fixpoint_steps
 				<< " steps without reaching a fixpoint, giving up";
@@ -711,7 +748,7 @@ std::pair<tref, int_t> find_fixpoint_chi(tref chi_base, tref st,
 	// SO-1: same unbounded-search concern, and the same reachable cap, as
 	// find_fixpoint_phi above.
 	constexpr int_t max_fixpoint_steps = 500;
-	while (step_num < lookback || !is_nso_impl<node>(chi_prev_replc, chi_replc))
+	while (step_num < lookback || !fixpoint_reached<node>(chi_prev_replc, chi_replc))
 	{
 		if (step_num >= max_fixpoint_steps) {
 			LOG_ERROR << "find_fixpoint_chi: exceeded " << max_fixpoint_steps

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TESTS
 	nso_rr
 	product_ba
 	ref_variables_resolver
+	fixpoint_conjunct_split
 	sbf_ba_parsing
 	sbf_ba_splitter
 	tau_ba

--- a/tests/unit/test_fixpoint_conjunct_split.cpp
+++ b/tests/unit/test_fixpoint_conjunct_split.cpp
@@ -1,0 +1,113 @@
+// Regression test for the per-conjunct fixpoint check.
+//
+// `fixpoint_reached(prev, next)` splits `next` into its top-level conjuncts and
+// checks `prev |= c` for each. That rests on an elementary equivalence:
+//
+//     phi |= psi_1 & ... & psi_n   <=>   for all i. phi |= psi_i
+//
+// so the split must never change the answer. These cases pin exactly that, and
+// they are written so that a broken split FAILS:
+//   * a conjunction whose LAST conjunct is not implied catches a collector that
+//     only walks the first branch, and an early exit that returns too soon;
+//   * a conjunction that is implied catches an inverted return.
+//
+// The reference is a DIRECT `is_nso_impl` call, not the helper with the flag
+// off. Two reasons, and the second one bit us:
+//   * `is_nso_impl` is what the helper has to agree with -- that is the contract,
+//     while "helper with the flag off" is only a proxy for it;
+//   * the flag is `fixpoint_conjunct_split || env_enabled`, so with
+//     TAU_QE_FIXSPLIT set in the environment the "off" side is ON as well and the
+//     comparison degenerates to on-vs-on. A suite run with the switch enabled
+//     would then pass this file without testing anything.
+//
+// What this does NOT test: that the split is faster. It cannot -- the change is
+// semantically neutral, so the only in-process observable is time, and time does
+// not belong in an assertion. The effect is documented with measurements instead.
+// Nor does the non-conjunction case prove the fallback is taken: a collector that
+// returns a single-element list gives the same answer. It pins the answer, not
+// the path.
+
+#include "test_init.h"
+#include "test_tau_helpers.h"
+
+namespace {
+
+// `x = 0` for a fresh atomless-typed variable.
+tref atom(const char* name) {
+	return tau::build_bf_eq_0(
+		build_bf_variable<node_t>(name, tau_type_id<node_t>()));
+}
+
+// The undecomposed reference answer, and the split one. Both must agree.
+// `ref` is a direct `is_nso_impl` so the test holds even when TAU_QE_FIXSPLIT is
+// set in the environment (see the note at the top of this file).
+std::pair<bool, bool> ref_and_split(tref prev, tref next) {
+	const bool ref = is_nso_impl<node_t>(prev, next);
+	api<node_t>::set_fixpoint_conjunct_split(true);
+	const bool split = fixpoint_reached<node_t>(prev, next);
+	api<node_t>::set_fixpoint_conjunct_split(false);
+	return {ref, split};
+}
+
+} // namespace
+
+TEST_SUITE("configuration") {
+	TEST_CASE("bdd_init") { bdd_init<Bool>(); }
+}
+
+TEST_SUITE("fixpoint check per conjunct") {
+
+	TEST_CASE("conjunction that is implied") {
+		tref a = atom("fcs_a"), b = atom("fcs_b");
+		tref prev = tau::build_wff_and(a, b);
+		tref next = tau::build_wff_and(a, b);
+		auto [ref, split] = ref_and_split(prev, next);
+		CHECK( ref == split );
+		CHECK( split );
+	}
+
+	TEST_CASE("first conjunct not implied") {
+		tref a = atom("fcs_c"), b = atom("fcs_d");
+		tref prev = b;
+		tref next = tau::build_wff_and(a, b);
+		auto [ref, split] = ref_and_split(prev, next);
+		CHECK( ref == split );
+		CHECK( !split );
+	}
+
+	// The one that catches a collector walking only one branch, and an early
+	// exit that stops before the last conjunct.
+	TEST_CASE("last conjunct not implied") {
+		tref a = atom("fcs_e"), b = atom("fcs_f"), c = atom("fcs_g");
+		tref prev = tau::build_wff_and(a, b);
+		tref next = tau::build_wff_and(tau::build_wff_and(a, b), c);
+		auto [ref, split] = ref_and_split(prev, next);
+		CHECK( ref == split );
+		CHECK( !split );
+	}
+
+	TEST_CASE("nested conjunction, middle conjunct not implied") {
+		tref a = atom("fcs_h"), b = atom("fcs_i"), c = atom("fcs_j");
+		tref prev = tau::build_wff_and(a, c);
+		tref next = tau::build_wff_and(a, tau::build_wff_and(b, c));
+		auto [ref, split] = ref_and_split(prev, next);
+		CHECK( ref == split );
+		CHECK( !split );
+	}
+
+	// Not a conjunction. This pins the ANSWER on that path; it cannot pin that
+	// the fallback was taken (see the note at the top).
+	TEST_CASE("single atom, not a conjunction") {
+		tref a = atom("fcs_k");
+		auto [ref, split] = ref_and_split(a, a);
+		CHECK( ref == split );
+		CHECK( split );
+	}
+
+	TEST_CASE("single atom not implied") {
+		tref a = atom("fcs_l"), b = atom("fcs_m");
+		auto [ref, split] = ref_and_split(a, b);
+		CHECK( ref == split );
+		CHECK( !split );
+	}
+}


### PR DESCRIPTION
Opt-in, off by default. The measurement, the reproducer and the growth this
comes from are in #82; this is the change that follows from it.

### The change

`find_fixpoint_phi` decides whether a fixpoint is reached with

```cpp
while (step_num < lookback || !is_nso_impl<node>(phi_prev, phi))
```

`phi` is a top-level conjunction by construction: `find_fixpoint_phi` builds
`phi_prev = build_wff_and(ctn_initials, …)` and every step replaces an inner
placeholder, so the outer `wff_and` survives. It collapses only if one side is `T`,
and then the patch falls back to the single call. For `chi` we make no such claim —
same shape, no structural guarantee. Implication distributes over a conjunction:

```
    φ ⊨ ψ₁ ∧ … ∧ ψₙ   ⟺   ∀i. φ ⊨ ψᵢ
```

The patch factors this into a helper `fixpoint_reached(prev, next)` that splits
`next` into its top-level conjuncts and checks them one at a time, returning at the
first conjunct that is not implied. It is used at **both** fixpoint checks —
`find_fixpoint_phi` and `find_fixpoint_chi` — which had the same shape. +57/-2 across
five files (the check, the flag, the `api` setter, the CMake entry), plus the new
test file.

`is_nso_impl` does not decompose conjunctions itself, and neither does any caller
we could find, so this is not duplicated elsewhere. Its other live call site,
`eliminate_implied` in `simplify_temporal_clause`, uses it pairwise over the `always`
parts of a clause; we did not measure that path and this patch does not touch it.

**Scope of the evidence:** all timings below come from the `find_fixpoint_phi`
path. `find_fixpoint_chi` has the same shape and uses the same helper, but we have
not built a spec that exercises it, so its effect there is untested. The helper
itself is covered by the unit test either way. If you would rather keep the change
to `find_fixpoint_phi` until that is measured, that is easy to do.

This is an elementary equivalence — it needs no assumption about the conjuncts. On the
one spec where we instrumented the call the conjuncts happened to have disjoint
supports, which would explain why the individual checks are cheaper, but that is an
observation on one spec and not a precondition for the change.

### Why it is cheaper

Splitting turns one check into `n`, so the gain has to come from each check being
much cheaper than the whole. `is_nso_impl` builds `∀vars. (φ → ψ)` and hands it to
`normalize_non_temp`, which reaches the Boole decomposition — and that is
exponential in the atom count of the formula it decomposes. Splitting replaces one
decomposition over all of `ψ`'s atoms by `n` decompositions over roughly `1/n` of
them each.

We did not measure the atom count per individual check, so this reading is not
directly confirmed. What we can offer is one control that rules out the simpler
explanation:

- **It is not the quantified-variable count.** We also tried narrowing the left-hand
  side per conjunct — dropping the conjuncts of `φ` whose support is disjoint from
  `ψᵢ`. That reduces the free variables of the implication from 40 to 0 and buys
  only 6 %. So whatever the saving is, it is not in how many variables are
  quantified.

Beyond that the evidence is the measured ladder below: the gain grows with `N`,
which is what one expects if the cost is superlinear in the size of what is
decomposed, and not what one expects from a fixed overhead.

Off by default, enabled by `api::set_fixpoint_conjunct_split(true)` or the
`TAU_QE_FIXSPLIT` environment variable — the same shape as #75 and #77. If you would
rather have it on by default, we are happy to change that.

`feature/ltl-rebased` is currently changing both files this touches on
(`satisfiability.tmpl.h` and `normalizer.tmpl.h`, where `is_nso_impl` lives). The two
lines the patch replaces are unchanged there, so it should still apply — but you are
in a much better position than we are to judge how it fits alongside that work, and we
are happy to rebase or hold it.

### Test

`tests/unit/test_fixpoint_conjunct_split.cpp`, 7 cases, registered in CMake. Each
case compares the helper against a **direct `is_nso_impl` call** and requires the two
to agree, plus the expected answer.

The reference is the direct call rather than "the helper with the switch off", for
two reasons. It is the contract the helper has to meet. And since the flag reads
`fixpoint_conjunct_split || env_enabled`, a run with `TAU_QE_FIXSPLIT` set in the
environment would make the "off" side on as well — the file would pass without
testing anything, in exactly the suite run we call the informative one.

Two cases are written to fail on a broken split: a conjunction whose **last**
conjunct is not implied (catches a collector that only walks one branch, and an early
exit that stops too soon), and a **nested** conjunction with the failing conjunct in
the middle.

What the test cannot show is that the split is faster: the change is semantically
neutral, so the only in-process observable is time, and time does not belong in an
assertion. It also cannot show that the non-conjunction path takes the fallback — a
collector returning a one-element list gives the same answer. It pins the answer,
not the path. The speed is documented by the measurements above — same caveat as our
#77.

### Effect

Same tree, one binary, switch off/on, one process per data point, memory-capped:

| N clauses | off | on | |
|---|---|---|---|
| 1 | 0.22 s | 0.21 s | 1.0x |
| 5 | 0.36 s | 0.36 s | 1.0x |
| 20 | 7.9 s | 5.1 s | 1.5x |
| 25 | 36.1 s | 9.6 s | 3.8x |
| 28 | **99.3 s** | **12.2 s** | **8.1x** |

The interesting part is not the factor but the growth: from N=20 to N=28 the
unsplit check grows by 12.5x, the split one by 2.4x. That is why the factor rises with
`N` rather than staying put.

**Outputs are identical on both sides at every point in the table** — the result
lines of each run compared verbatim. The spec is the one in the issue, and our other
two opt-in patches are off on both sides, so the comparison isolates this change
against the base.

### What this does not do

- It does not touch the cost of an individual check; it only stops paying for all
  of them at once. If the right-hand side is a single atom, nothing changes, and on
  specs where `phi` is not a conjunction the patch falls back to the original call.
- On one-off `sat`/`valid` queries we measured no effect at all.
- We have not measured a case where `phi` has many conjuncts and each check is
  already cheap. Splitting turns one call into `n`, so that is the shape in which it
  could cost rather than save; we say so because we have not ruled it out.

### Testing

- Suite: **333/333**, Release, one build and two `ctest` runs — switch off (118 s)
  and on (112 s), no failures either way. The run with the switch on is the
  informative one: the split is then active in every interpreter test in the suite,
  not only in ours.
  Two caveats, both ours: that run was on a tree that also carries #75, #81 and #77
  (hence 333 = your 328 plus five binaries of ours) rather than on this branch alone,
  and there was no Debug run. We are happy to repeat either on this branch before a
  merge. On this branch we have built and run the new unit test itself — 12/12, with
  and without the environment variable.
- Our own end-to-end battery: 19 scenario blocks against a host built from this
  branch, all passing, with every expected output unchanged — including the
  state-accumulating replay that motivated the change. Explicit host override, so it
  is a candidate measurement rather than a run against defaults.
- The three load-bearing points (N=20/25/28) were measured twice, on two different
  build trees on different days; the pairs agree to within 3.3 %. One machine.