### PR TITLE
Opt-in: decide a `:tau` constant's sat/valid per support component, in its zero/one tests and in `simp_tau_unsat_valid`

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -250,6 +250,9 @@ struct api {
 	static void set_max_revision_alts(size_t n);
 	/** @brief Enable/disable indenting in pretty-printed output. */
 	static void set_indenting(bool state);
+	/// Enable/disable support-component factoring of the Tau-BA
+	/// constant/valid tests (tau_ba.tmpl.h). Off by default.
+	static void set_ba_component_factoring(bool state);
 	/** @brief Enable/disable ANSI colour highlighting in output. */
 	static void set_highlighting(bool state);
 	/** @brief Enable/disable JSON output mode. */

--- a/src/api.tmpl.h
+++ b/src/api.tmpl.h
@@ -156,6 +156,11 @@ void api<node>::set_indenting(bool indenting) {
 }
 
 template <NodeType node>
+void api<node>::set_ba_component_factoring(bool state) {
+	ba_component_factoring = state;
+}
+
+template <NodeType node>
 void api<node>::set_highlighting(bool highlighting) {
 	pretty_printer_highlighting = highlighting;
 }

--- a/src/boolean_algebras/tau_ba.h
+++ b/src/boolean_algebras/tau_ba.h
@@ -24,6 +24,13 @@
 
 namespace idni::tau_lang {
 
+/// Opt-in for support-component factoring of the Tau-BA constant/valid
+/// tests (`is_zero`/`is_one`; see the note in tau_ba.tmpl.h). Off by
+/// default; enabled via `api::set_ba_component_factoring(true)` or the
+/// environment variable TAU_BA_COMPONENT_FACTORING (a value of "0"
+/// disables).
+inline bool ba_component_factoring = false;
+
 // Check https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102609 to follow up on
 // the implementation of "Deducing this" on gcc.
 // See also (https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0847r7.html)

--- a/src/boolean_algebras/tau_ba.tmpl.h
+++ b/src/boolean_algebras/tau_ba.tmpl.h
@@ -4,6 +4,8 @@
 
 #include "tau_spec.h"
 
+#include <cstdlib>
+
 #undef LOG_CHANNEL_NAME
 #define LOG_CHANNEL_NAME "tau_ba"
 
@@ -142,12 +144,165 @@ static bool cached_tau_ba_predicate(const tau_ba<BAs...>& fm,
 	return cache.insert_or_assign(key, res).first->second;
 }
 
+/**
+ * @internal
+ * @brief Per-support-component sat/valid decision for a `:tau` constant.
+ *
+ * `is_zero`/`is_one` decide a constant by running the full temporal decision
+ * procedure over its formula. When that formula is a conjunction of units
+ * with pairwise disjoint free supports -- the shape a constant takes when
+ * independent clauses accumulate into it -- every question pays for all
+ * units, although the answer factors: a model of each unit assigns only its
+ * own variables, so models over disjoint supports compose, and validity
+ * distributes over conjunction. `factored_tau_sat`/`factored_tau_valid`
+ * decide per unit group and cache the verdicts per group (the `create_cache`
+ * discipline of `cached_tau_ba_predicate`, compute before emplace), so a
+ * constant that grows by one clause pays for that clause.
+ *
+ * Supports are compared by variable NAME, not by variable node: `o1[t]`,
+ * `o1[t-1]` and `o1[0]` are one stream and must land in one group (a
+ * node-identity grouping such as `group_by_shared_vars` would keep them
+ * apart); the time offset variable is not part of the support
+ * (`get_free_vars` does not descend into io variables). Bound-variable names
+ * are included, which can only merge groups, never split them.
+ *
+ * Conservative gates, each falling back to the monolithic path: any embedded
+ * BA constant inside a unit (its support is invisible from the outside), any
+ * free variable without a printable name, fewer than two groups. A single
+ * `always` hull is split into per-unit hulls first (`always` distributes
+ * over conjunction). Both decisions are taken at start time 0, which is the
+ * only start time the callers use.
+ * @endinternal
+ */
+template <typename node>
+static int factored_tau_units(tref fm, trefs& units) {
+	using tau = tree<node>;
+	trefs clauses = get_cnf_wff_clauses<node>(fm);
+	for (size_t i = 0; i < clauses.size(); ++i) {
+		if (tau::get(clauses[i]).child_is(tau::wff_always)) {
+			trefs aw = get_cnf_wff_clauses<node>(
+				tau::trim2(clauses[i]));
+			clauses[i] = tau::build_wff_always(aw[0]);
+			for (size_t j = 1; j < aw.size(); ++j)
+				clauses.push_back(
+					tau::build_wff_always(aw[j]));
+		}
+	}
+	if (clauses.size() < 2) return -1;
+	units = std::move(clauses);
+	return 0;
+}
+
+inline bool ba_component_factoring_enabled() {
+	static const bool env = [] {
+		const char* v = std::getenv("TAU_BA_COMPONENT_FACTORING");
+		return v && *v && !(v[0] == '0' && v[1] == '\0');
+	}();
+	return ba_component_factoring || env;
+}
+
+// Component-wise satisfiability; -1 = not applicable (fall back), 0 = unsat,
+// 1 = sat.
+template <typename node>
+static int factored_tau_sat(tref fm) {
+	using tau = tree<node>;
+	trefs units;
+	if (factored_tau_units<node>(fm, units) < 0) return -1;
+	for (tref u : units)
+		if (tau::get(u).find_top([](tref t) {
+			return tree<node>::get(t).is_ba_constant(); }))
+			return -1;
+	std::vector<std::vector<std::string>> supp(units.size());
+	for (size_t i = 0; i < units.size(); ++i)
+		for (tref v : tau::get(units[i]).get_free_vars()) {
+			const std::string& nm = get_var_name<node>(v);
+			if (nm.empty()) return -1;
+			supp[i].push_back(nm);
+		}
+	std::vector<std::vector<std::string>> cn;
+	std::vector<trefs> cc;
+	auto shares = [](const std::vector<std::string>& a,
+			 const std::vector<std::string>& b) {
+		for (const auto& x : a) for (const auto& y : b)
+			if (x == y) return true;
+		return false;
+	};
+	for (size_t i = 0; i < units.size(); ++i) {
+		std::vector<size_t> hit;
+		for (size_t c = 0; c < cn.size(); ++c)
+			if (shares(cn[c], supp[i])) hit.push_back(c);
+		if (hit.empty()) {
+			cn.push_back(supp[i]);
+			cc.push_back(trefs{ units[i] });
+			continue;
+		}
+		size_t base = hit[0];
+		cn[base].insert(cn[base].end(),
+			supp[i].begin(), supp[i].end());
+		cc[base].push_back(units[i]);
+		for (size_t k = hit.size(); k-- > 1; ) {
+			size_t c = hit[k];
+			cn[base].insert(cn[base].end(),
+				cn[c].begin(), cn[c].end());
+			cc[base].insert(cc[base].end(),
+				cc[c].begin(), cc[c].end());
+			cn.erase(cn.begin() + c);
+			cc.erase(cc.begin() + c);
+		}
+	}
+	if (cc.size() < 2) return -1;
+	using cache_t = subtree_unordered_map<node, bool>;
+	static cache_t& cache = tree<node>::template create_cache<cache_t>();
+	bool all_sat = true;
+	for (size_t c = 0; c < cc.size() && all_sat; ++c) {
+		tref f = cc[c][0];
+		for (size_t j = 1; j < cc[c].size(); ++j)
+			f = tau::build_wff_and(f, cc[c][j]);
+		if (auto it = cache.find(f); it != cache.end()) {
+			all_sat = it->second;
+			continue;
+		}
+		// compute() before emplace: it can create new trees, and a
+		// rehash of `cache` must not happen with a half-built entry.
+		bool sres = is_tau_formula_sat<node>(f);
+		cache.insert_or_assign(f, sres);
+		all_sat = sres;
+	}
+	return all_sat ? 1 : 0;
+}
+
+// Unit-wise validity (distributes over conjunction unconditionally);
+// -1 = not applicable, 0 = not valid, 1 = valid.
+template <typename node>
+static int factored_tau_valid(tref fm) {
+	using tau = tree<node>;
+	trefs units;
+	if (factored_tau_units<node>(fm, units) < 0) return -1;
+	using cache_t = subtree_unordered_map<node, bool>;
+	static cache_t& cache = tree<node>::template create_cache<cache_t>();
+	bool all = true;
+	for (size_t i = 0; i < units.size() && all; ++i) {
+		if (auto it = cache.find(units[i]); it != cache.end()) {
+			all = it->second;
+			continue;
+		}
+		bool vres = is_tau_impl<node>(tau::_T(), units[i]);
+		cache.insert_or_assign(units[i], vres);
+		all = vres;
+	}
+	return all ? 1 : 0;
+}
+
 template <typename... BAs>
 requires BAsPack<BAs...>
 bool tau_ba<BAs...>::is_zero() const {
 	using cache_t = subtree_unordered_map<node, bool>;
 	static cache_t& cache = tau::template create_cache<cache_t>();
 	return cached_tau_ba_predicate(*this, cache, [](tref normalized) {
+		if (ba_component_factoring_enabled())
+			if (int r = factored_tau_sat<node>(normalized);
+					r >= 0)
+				return r == 0;
 		return !is_tau_formula_sat<node>(normalized);
 	});
 }
@@ -158,6 +313,10 @@ bool tau_ba<BAs...>::is_one() const {
 	using cache_t = subtree_unordered_map<node, bool>;
 	static cache_t& cache = tau::template create_cache<cache_t>();
 	return cached_tau_ba_predicate(*this, cache, [](tref normalized) {
+		if (ba_component_factoring_enabled())
+			if (int r = factored_tau_valid<node>(normalized);
+					r >= 0)
+				return r == 1;
 		return is_tau_impl<node>(tau::_T(), normalized);
 	});
 }

--- a/src/satisfiability.h
+++ b/src/satisfiability.h
@@ -198,6 +198,13 @@ bool are_tau_equivalent(tref f1, tref f2);
  * // not guarantee a particular normal form for the surviving disjuncts.
  * @endcode
  */
+// Support-component factoring (defined in boolean_algebras/tau_ba.tmpl.h,
+// same translation unit): used by simp_tau_unsat_valid below to decide its
+// per-path satisfiability tests unit-wise where that is exact.
+inline bool ba_component_factoring_enabled();
+template <typename node> static int factored_tau_sat(tref fm);
+template <typename node> static int factored_tau_valid(tref fm);
+
 template <NodeType node>
 tref simp_tau_unsat_valid(tref fm, const int_t start_time = 0,
 				const bool output = false);

--- a/src/satisfiability.tmpl.h
+++ b/src/satisfiability.tmpl.h
@@ -1646,16 +1646,29 @@ template <NodeType node>
 tref simp_tau_unsat_valid(tref fm, const int_t start_time, const bool output) {
 	using tau = tree<node>;
 	LOG_DEBUG << "Start simp_tau_unsat_valid: " << LOG_FM(fm);
-	// Check if formula is valid
-	if (is_tau_impl<node>(tau::_T(), fm)) return tau::_T();
+	// Check if formula is valid. Validity distributes over conjunction, so
+	// where the formula is a conjunction of independent units the unit-wise
+	// verdict is exact and cheap; the monolithic check stays for the rest.
+	// (Measured on an accumulating run with a 137-clause `:tau` constant: the per-path
+	// transform below cost ~62 s per rejection while returning the formula
+	// unchanged; unit-wise it is milliseconds, with the same paths kept.)
+	// The unit-wise verdicts are taken at start time 0 (the only start time
+	// the caller uses); any other start time keeps the monolithic checks.
+	const bool factor = ba_component_factoring_enabled() && start_time == 0;
+	int fv = factor ? factored_tau_valid<node>(fm) : -1;
+	if (fv == 1) return tau::_T();
+	if (fv < 0 && is_tau_impl<node>(tau::_T(), fm)) return tau::_T();
 	tref normalized_fm = normalize_with_temp_simp<node>(fm);
 	trefs clauses = {tau::_F()};
-	// Check satisfiability of each clause
-	for (tref clause: expression_paths<node>(normalized_fm))
-		if (!tau::get(transform_to_execution<node>(
-			clause, start_time, output)).equals_F()) {
-			clauses.push_back(clause);
-		}
+	// Check satisfiability of each clause -- unit-wise where exact
+	for (tref clause: expression_paths<node>(normalized_fm)) {
+		bool keep;
+		int fs = factor ? factored_tau_sat<node>(clause) : -1;
+		if (fs >= 0) keep = (fs == 1);
+		else keep = !tau::get(transform_to_execution<node>(
+			clause, start_time, output)).equals_F();
+		if (keep) clauses.push_back(clause);
+	}
 	tref res = tau::build_wff_or(clauses);
 	LOG_DEBUG << "End simp_tau_unsat_valid: " << LOG_FM(res);
 	return res;

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TESTS
 	blasting_correctness_check5
 	bv_stress_check
 	ba_component_factoring
+	simp_tau_unsat_valid_unitwise
 )
 
 foreach(X IN LISTS TESTS)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -47,6 +47,7 @@ set(TESTS
 	blasting_correctness_check4
 	blasting_correctness_check5
 	bv_stress_check
+	ba_component_factoring
 )
 
 foreach(X IN LISTS TESTS)

--- a/tests/integration/test_integration-ba_component_factoring.cpp
+++ b/tests/integration/test_integration-ba_component_factoring.cpp
@@ -1,0 +1,72 @@
+// To view the license please visit https://github.com/IDNI/tau-lang/blob/main/LICENSE.md
+
+// Support-component factoring of the Tau-BA constant/valid tests.
+//
+// sat over a conjunction whose conjuncts share no free variables factors
+// exactly (models over disjoint supports compose); validity distributes over
+// conjunction unconditionally. Enabling the factoring must therefore not
+// change any answer. The cases below cover: a factorable satisfiable corpus,
+// a corpus that is unsat INSIDE one component (the early-exit path), a
+// coupled corpus (shared stream => components merge => the identity is not
+// even needed), and a unit containing an embedded constant, which must take
+// the conservative fallback (exercise of the guard, not just of the fast
+// path -- a miss-only test would prove nothing about the gate).
+
+#include "test_integration-satisfiability_helper.h"
+
+using tau_api = api<node_t>;
+
+namespace {
+
+bool api_sat(const std::string& s) {
+	tref f = tau_api::get_formula_or_term(s.c_str());
+	REQUIRE(f != nullptr);
+	return tau_api::sat(f);
+}
+
+struct factoring_config {
+	factoring_config(bool on) { ba_component_factoring = on; }
+	~factoring_config() { ba_component_factoring = false; }
+};
+
+// Three independent rules over disjoint streams: satisfiable.
+const char* DISJOINT_SAT =
+	"{ (o1[t] = 1 -> o2[t] = 1) && (o3[t] = 1 -> o4[t] = 1)"
+	" && (o5[t] = 0) }:tau != 0";
+// Unsat inside one component (o1 pinned to both values), others untouched.
+const char* COMPONENT_UNSAT =
+	"{ (o1[t] = 1) && (o1[t] = 0) && (o3[t] = 1 -> o4[t] = 1) }:tau != 0";
+// Coupled: o1 appears in two conjuncts, the components merge.
+const char* COUPLED_SAT =
+	"{ (o1[t] = 1 -> o2[t] = 1) && (o1[t] = 1 -> o4[t] = 1) }:tau != 0";
+// A unit embedding another BA constant: support is invisible, the factoring
+// must fall back to the monolithic path.
+const char* EMBEDDED_FALLBACK =
+	"{ (o1[t]:tau = { o6[t] = 1 }) && (o3[t] = 1 -> o4[t] = 1) }:tau != 0";
+
+} // namespace
+
+TEST_SUITE("tau ba component factoring") {
+
+	TEST_CASE("answers are unchanged with factoring enabled") {
+		bool r1, r2, r3, r4;
+		{
+			factoring_config off(false);
+			r1 = api_sat(DISJOINT_SAT);
+			r2 = api_sat(COMPONENT_UNSAT);
+			r3 = api_sat(COUPLED_SAT);
+			r4 = api_sat(EMBEDDED_FALLBACK);
+		}
+		CHECK(r1 == true);
+		CHECK(r2 == false);
+		{
+			factoring_config on(true);
+			CHECK(api_sat(DISJOINT_SAT) == r1);
+			CHECK(api_sat(COMPONENT_UNSAT) == r2);
+			CHECK(api_sat(COUPLED_SAT) == r3);
+			CHECK(api_sat(EMBEDDED_FALLBACK) == r4);
+			// Warm component caches: repeat.
+			CHECK(api_sat(DISJOINT_SAT) == r1);
+		}
+	}
+}

--- a/tests/integration/test_integration-simp_tau_unsat_valid_unitwise.cpp
+++ b/tests/integration/test_integration-simp_tau_unsat_valid_unitwise.cpp
@@ -1,0 +1,73 @@
+// To view the license please visit https://github.com/IDNI/tau-lang/blob/main/LICENSE.md
+
+// Unit-wise decision of simp_tau_unsat_valid's per-path tests.
+//
+// normalize_tau feeds every embedded :tau constant through
+// simp_tau_unsat_valid, which decides validity of the element and then the
+// satisfiability of each DNF path. Where the element is a conjunction of
+// units with pairwise disjoint free supports, validity distributes over the
+// conjunction and satisfiability factors over the supports, so the unit-wise
+// verdicts are exact; everywhere else the monolithic checks stay. With the
+// component factoring enabled the normal form must therefore be byte-identical
+// to the stock one. The cases cover: a factorable element (fast path), an
+// element with one unsat unit (the F path), a coupled element (no split), and
+// an element that is a disjunction of conjunctions (path enumeration must
+// still see every path).
+
+#include "test_integration-satisfiability_helper.h"
+
+using tau_api = api<node_t>;
+
+namespace {
+
+std::string api_normalize(const std::string& s) {
+	tref f = tau_api::get_formula_or_term(s.c_str());
+	REQUIRE(f != nullptr);
+	tref n = tau_api::normalize_formula(f);
+	REQUIRE(n != nullptr);
+	return tau::get(n).to_str();
+}
+
+struct factoring_config {
+	factoring_config(bool on) { ba_component_factoring = on; }
+	~factoring_config() { ba_component_factoring = false; }
+};
+
+// Independent units, all satisfiable: the element stays as it is.
+const char* FACTORABLE =
+	"o9[t]:tau = { (o1[t] = 1 -> o2[t] = 1) && (o3[t] = 1 -> o4[t] = 1)"
+	" && (o5[t] = 0) }";
+// One unit unsat (o1 pinned both ways): the element collapses to F.
+const char* UNIT_UNSAT =
+	"o9[t]:tau = { (o1[t] = 1) && (o1[t] = 0) && (o3[t] = 1 -> o4[t] = 1) }";
+// Coupled units share o1: no split is possible, monolithic path.
+const char* COUPLED =
+	"o9[t]:tau = { (o1[t] = 1 -> o2[t] = 1) && (o1[t] = 1 -> o4[t] = 1) }";
+// Two paths, one of them unsat: the unsat path must still be dropped.
+const char* TWO_PATHS =
+	"o9[t]:tau = { ((o1[t] = 1) && (o1[t] = 0)) || ((o3[t] = 1) && (o5[t] = 0)) }";
+
+} // namespace
+
+TEST_SUITE("simp_tau_unsat_valid unit-wise") {
+
+	TEST_CASE("normal forms are byte-identical with factoring enabled") {
+		std::string s1, s2, s3, s4;
+		{
+			factoring_config off(false);
+			s1 = api_normalize(FACTORABLE);
+			s2 = api_normalize(UNIT_UNSAT);
+			s3 = api_normalize(COUPLED);
+			s4 = api_normalize(TWO_PATHS);
+		}
+		{
+			factoring_config on(true);
+			CHECK(api_normalize(FACTORABLE) == s1);
+			CHECK(api_normalize(UNIT_UNSAT) == s2);
+			CHECK(api_normalize(COUPLED) == s3);
+			CHECK(api_normalize(TWO_PATHS) == s4);
+			// Warm caches: repeat the factorable case.
+			CHECK(api_normalize(FACTORABLE) == s1);
+		}
+	}
+}


### PR DESCRIPTION
## What this is

One small tool and two callers, all opt-in. The tool (first commit) splits a
`:tau` constant into units with pairwise disjoint free supports and decides
`sat` and `valid` per unit, with the verdicts cached per unit. The first
caller is the constant's own zero/one test (`is_zero`/`is_one`); the second
(second commit) is `simp_tau_unsat_valid`, where `normalize_tau` decides the
validity of an embedded constant and the satisfiability of each of its paths
-- on the accumulating-constant run from #76 that second place is where the
remaining cost sits.

It is the other side of what `f4954c22` (#72) already does: there the
conjuncts inside `anti_prenex_block` are grouped by shared variables before
they are decided; here the same grouping is applied to the constant itself,
which that code path does not see. Meant as a companion, not a replacement --
if you would rather fold it into your own component code, the test and the
numbers below should transfer as they are.

Off by default. `api::set_ba_component_factoring(true)` or
`TAU_BA_COMPONENT_FACTORING=1` (for CLI runs) switches it on.

## What it does

When the constant is a conjunction of units with pairwise disjoint free
supports:

* the tool: split the units along the conjunction (an `always` hull is
  split over `&&` first), group them by shared variable names, decide
  `sat`/`valid` per group, cache the verdicts in the `create_cache`
  registry -- so a constant that grows by one clause pays for that clause;
* caller 1, `is_zero` / `is_one`: use the per-group verdicts instead of
  deciding the whole constant;
* caller 2, `simp_tau_unsat_valid`: use them for the validity pre-check and
  for the per-path "not F" test; the paths kept and the formula rebuilt are
  unchanged.

Anything that is not such a conjunction takes the old path unchanged: a
unit that embeds another BA constant, unnamed free variables, fewer than
two components.

The reason this cannot change an answer is the usual one: models over
disjoint supports compose, and validity distributes over conjunction
(the same decomposition Bayardo & Pehoushek use for model counting, and
the "keep the parts, not the product" idea of partitioned transition
relations).

## Numbers

The 142-step script from #76 (issuecomment-5437153176), `ee84f6e0` plus
this branch, `--block-max-splits 1`, 8 MB stack, one 4-core Linux box:

| | switch off | switch on |
|---|---|---|
| sum of step times, 142 steps | 396 s | 21 s |
| wall | 7 min 0 s | 31 s |
| per-step cost at step 10 / 60 / 100 / 137 | 59 / 723 / 3048 / 15888 ms | 37 / 111 / 222 / 302 ms |
| peak RSS | 140 MB | 141 MB |
| outputs | reference | byte-identical: every output-stream line (426 lines, 475,940 bytes), and the whole output minus the timing lines, `diff` empty |

Same binary, only the switch differs -- so the byte-identity is measured, not argued: the switch changes how the constant is decided, not what comes out. The first step (about 145 ms either
way) is not touched by this; that one is the DNF expansion inside
`anti_prenex_block`, written up in #90.

## Tests

* `test_integration-ba_component_factoring`: answers unchanged with the
  switch on, including the embedded-constant fallback.
* `test_integration-simp_tau_unsat_valid_unitwise` (new): normal forms of
  four element shapes (factorable, one unit unsat, coupled, two paths) are
  byte-identical with the switch off and on.
* Full suites: Release 443/443 (off) and 443/443 (on) on this branch
  before the one-line start-time guard was added (the guard takes the same
  path at start time 0, the only one exercised); Debug 443/443 (off) and
  443/443 (on) on the same code with an unrelated memo commit still
  present. Happy to rerun either on the exact commits if you want the
  numbers on the hash.

Two things worth a look in review. The support test is by variable name,
not by variable node: `o1[t]`, `o1[t-1]` and `o1[0]` are one stream and have
to land in one group, which is why this does not reuse `group_by_shared_vars`
from `f4954c22` (that one links by node identity, which is the right thing
for a quantifier block and the wrong thing for a stream). And bound-variable
names are included on purpose, which can only merge groups, never split
them. The unit-wise path is only taken at start time 0, the only start time
the caller uses; anything else keeps the old checks.

Addresses the accumulating-constant half of #76.
