### PR TITLE
Cache free-variable sets of connective and binder subtrees in `get_free_vars`

### DIFF
--- a/src/tau_tree_extractors.tmpl.h
+++ b/src/tau_tree_extractors.tmpl.h
@@ -573,6 +573,14 @@ int_t get_max_initial(const trefs& io_vars) {
 template <NodeType node>
 const trefs& get_free_vars(tref n) {
 	using tau = tree<node>;
+	// Cache/result shape: right-sibling-trimmed, sorted by subtree_less.
+	auto sorted_trimmed = [](const subtree_set<node>& vars) {
+		trefs out(vars.size());
+		size_t i = 0;
+		for (tref v : vars) out[i++] = tau::trim_right_sibling(v);
+		std::sort(out.begin(), out.end(), tau::subtree_less);
+		return out;
+	};
 
 	static const trefs no_free_vars{};
 
@@ -600,16 +608,41 @@ const trefs& get_free_vars(tref n) {
 			t.is(tau::bf_fall) || t.is(tau::bf_fex);
 	};
 	subtree_unordered_map<node, subtree_set<node>> memo;
-	std::function<const subtree_set<node>&(tref)> walk =
-		[&](tref m) -> const subtree_set<node>& {
+	// `spine`: m continues a chain of the same connective as its parent
+	// (the right operand of `a && (b && (c && ...))`). Its free-variable
+	// set is a suffix of the parent's; publishing it at every spine node
+	// would store k sets of size O(k) for a k-chain. Such nodes still
+	// read the cache (a chain that was a whole constant one step earlier
+	// is cached as the top-level result) but do not publish.
+	std::function<const subtree_set<node>&(tref, bool)> walk =
+		[&](tref m, bool spine) -> const subtree_set<node>& {
 		if (auto it = memo.find(m); it != memo.end()) return it->second;
 		const auto& t = tau::get(m);
+		// Connective and binder nodes are the only ones consulted in and
+		// published to the per-node cache: the walk fans out there, so that
+		// is where a cached result saves work, and leaving atoms and terms
+		// out keeps the cost of an extra lookup per node and of a cache
+		// entry per node (an insertion here, a visit in every
+		// garbage-collection sweep) off the paths made of small formulas.
+		const bool connective = t.is(tau::wff_and) || t.is(tau::wff_or);
+		const bool cacheable = connective || is_binder(t);
+		// A subtree's free-var set is intrinsic to it (see above), so a
+		// result the per-node cache already holds -- from an earlier call
+		// on this or on an enclosing formula -- is valid here as well:
+		// seed the walk from it instead of descending again.
+		if (cacheable) if (auto cached = free_vars_map.find(m);
+			cached != free_vars_map.end())
+		{
+			return memo.emplace(m, subtree_set<node>(
+				cached->second.begin(), cached->second.end()))
+					.first->second;
+		}
 		subtree_set<node> result;
 		if (is_binder(t)) {
 			// Fresh scope: only this binder's own subtree feeds it,
 			// mirroring the original push-scope-then-pop-and-merge.
 			for (tref c : t.children())
-				for (tref v : walk(c)) result.insert(v);
+				for (tref v : walk(c, false)) result.insert(v);
 			if (tref var = t.find_top(
 				(bool(*)(tref)) is_var_or_capture<node>); var)
 			{
@@ -637,16 +670,31 @@ const trefs& get_free_vars(tref n) {
 							jt->second.get().b))
 						result.insert(v);
 			}
-			for (tref c : t.children())
-				for (tref v : walk(c)) result.insert(v);
+			for (tref c : t.children()) {
+				// A wrapper (e.g. `wff`) between two connectives passes
+				// the spine flag through; a connective marks a child
+				// that wraps the same connective as its continuation.
+				const bool s = connective
+					? tau::get(c).child_is(t.is(tau::wff_and)
+						? tau::wff_and : tau::wff_or)
+					: spine;
+				for (tref v : walk(c, s)) result.insert(v);
+			}
 		}
+		// Publish the result of a connective or binder node to the per-node
+		// cache, in the same shape the top-level result takes below, so a
+		// later call -- on this subtree or on any formula containing it --
+		// does not walk it again. Before this, only the top-level result was
+		// cached and each miss re-walked every unchanged subtree; on an
+		// accumulating run that made the per-step cost superlinear in the
+		// number of accumulated clauses.
+		if (cacheable && !spine
+			&& free_vars_map.find(m) == free_vars_map.end())
+			free_vars_map.emplace(m, sorted_trimmed(result));
 		return memo.emplace(m, std::move(result)).first->second;
 	};
-	const subtree_set<node>& free_vars = walk(n);
-	trefs fv(free_vars.size());
-	size_t i = 0;
-	for (tref v : free_vars) fv[i++] = tau::trim_right_sibling(v);
-	std::sort(fv.begin(), fv.end(), tau::subtree_less);
+	const subtree_set<node>& free_vars = walk(n, false);
+	trefs fv = sorted_trimmed(free_vars);
 #ifdef DEBUG
 	LOG_TRACE << "End get_free_vars " << LOG_FM(n);
 	for (tref v : fv) LOG_TRACE << "\tfree var: " << LOG_FM(v);

--- a/tests/unit/test_tau_tree.cpp
+++ b/tests/unit/test_tau_tree.cpp
@@ -2,6 +2,9 @@
 
 #include "test_init.h"
 #include "test_tau_helpers.h"
+#include <set>
+#include <algorithm>
+#include <string>
 
 // ── tree::build_shift(const std::string&, size_t) (TT-1) ────────────────────
 
@@ -828,5 +831,76 @@ TEST_SUITE("get_free_vars edge inputs") {
 		const trefs& fv = get_free_vars<node_t>(tau::build_bf_fex(x, body));
 		REQUIRE(fv.size() == 1);
 		CHECK(get_var_name<node_t>(fv[0]) == "y");
+	}
+}
+// ── get_free_vars: per-subtree cache keeps scope handling intact ─────────────
+//
+// get_free_vars memoizes the free-variable sets of spine subtrees (binders,
+// and connectives with a connective or binder child) across calls. These
+// cases warm the cache through an enclosing formula and then ask for its
+// subtrees, checking that a cached answer equals a direct one: binder
+// subtraction still applies at every level, sibling context does not leak,
+// and the result stays trimmed and sorted.
+TEST_SUITE("get_free_vars cache") {
+
+	static std::set<std::string> names(const trefs& vs) {
+		std::set<std::string> out;
+		for (tref v : vs) out.insert(get_var_name<node_t>(v));
+		return out;
+	}
+	static tref var(const char* n) {
+		return tau::build_variable(std::string(n), tau_type_id<node_t>());
+	}
+
+	TEST_CASE("subtree answers after warming through the parent match direct ones") {
+		// F = ex a ((a=0 && (b=0 || c=0)) && ex d (d=0 && e=0))
+		tref left = tau::build_wff_and(x_eq_0("a"),
+			tau::build_wff_or(x_eq_0("b"), x_eq_0("c")));
+		tref inner_body = tau::build_wff_and(x_eq_0("d"), x_eq_0("e"));
+		tref inner = tau::build_wff_ex(var("d"), inner_body, false);
+		tref body = tau::build_wff_and(left, inner);
+		tref F = tau::build_wff_ex(var("a"), body, false);
+
+		// Warm: the whole formula first.
+		CHECK(names(get_free_vars<node_t>(F)) == std::set<std::string>{ "b", "c", "e" });
+		// Then every spine subtree, each of which the walk above visited.
+		CHECK(names(get_free_vars<node_t>(body)) == std::set<std::string>{ "a", "b", "c", "e" });
+		CHECK(names(get_free_vars<node_t>(inner)) == std::set<std::string>{ "e" });
+		CHECK(names(get_free_vars<node_t>(inner_body)) == std::set<std::string>{ "d", "e" });
+		CHECK(names(get_free_vars<node_t>(left)) == std::set<std::string>{ "a", "b", "c" });
+	}
+
+	TEST_CASE("results are sorted by subtree_less and right-sibling-trimmed") {
+		tref body = tau::build_wff_and(
+			tau::build_wff_and(x_eq_0("q"), x_eq_0("p")),
+			tau::build_wff_or(x_eq_0("s"), x_eq_0("r")));
+		tref F = tau::build_wff_ex(var("s"), body, false);
+		const trefs& fv = get_free_vars<node_t>(F);
+		REQUIRE(fv.size() == 3);
+		CHECK(std::is_sorted(fv.begin(), fv.end(), tau::subtree_less));
+		for (tref v : fv) CHECK(!tau::get(v).has_right_sibling());
+		// The cached body answer is the same vector shape, plus the bound one.
+		const trefs& bv = get_free_vars<node_t>(body);
+		REQUIRE(bv.size() == 4);
+		CHECK(std::is_sorted(bv.begin(), bv.end(), tau::subtree_less));
+		for (tref v : bv) CHECK(!tau::get(v).has_right_sibling());
+	}
+
+	TEST_CASE("an accumulating conjunction of independent clauses") {
+		// The shape from IDNI/tau-lang#90: k independent clauses conjoined one
+		// at a time, each query seeing the previous conjunction as a subtree.
+		tref acc = nullptr;
+		std::set<std::string> expect;
+		for (int i = 0; i < 40; ++i) {
+			std::string a = "u" + std::to_string(i), b = "v" + std::to_string(i);
+			tref clause = tau::build_wff_or(x_eq_0(a.c_str()), x_eq_0(b.c_str()));
+			acc = acc ? tau::build_wff_and(acc, clause) : clause;
+			expect.insert(a); expect.insert(b);
+			CHECK(names(get_free_vars<node_t>(acc)) == expect);
+		}
+		// Binding one variable at the top removes exactly that one.
+		tref F = tau::build_wff_ex(var("u7"), acc, false);
+		std::set<std::string> minus = expect; minus.erase("u7");
+		CHECK(names(get_free_vars<node_t>(F)) == minus);
 	}
 }


### PR DESCRIPTION
Follow-up to #90, on the per-step growth left open there; the measurements are in #92.

`get_free_vars` keeps a per-node cache but only ever stored the result of the node it was asked about; the recursive walk used a memo local to the call, so every cache miss re-walked all subtrees, including ones unchanged since the previous call. On a run that accumulates clauses into a `:tau` constant this made the per-step cost superlinear in the clause count (~k^2.8; 7.5 s per step at 137 clauses, most of it in this function).

The change consults and publishes the per-node cache at connective (`&&`/`||`) and binder nodes: the walk is seeded from a cached result there, and the result computed there is published in the same shape as the top-level result (right-sibling-trimmed, sorted). Atoms and terms — the bulk of the nodes — are neither looked up nor cached, since every cache entry is visited by each garbage-collection sweep and there is nothing to reuse below a connective. A subtree's free-variable set is intrinsic to it (the existing comment in the function says so), so the cached values stay correct.

Chain-continuation nodes — a child carrying the same connective as its parent, the right operand of `a && (b && (c && …))` — read the cache but do not publish. Their sets are suffixes of the parent's, and publishing them stores k sets of size O(k) for a k-chain: measured at 500 accumulated clauses, 127 529 cache entries and a peak RSS of 761 MB against 175 MB on `main` (unchanged at 137 clauses, where the first version of this PR was measured). The top-level result of the constant is cached as before, so the hit on the next step stays. Peak RSS at 500 clauses is back to 176 MB.

Measured on the #90 script (142 steps, `--block-max-splits 1`) against `main` @ 4ccdb1cd: step 137 from 7 516 ms to 2 433 ms, sum of steps from 311 s to 105 s; every verdict and the printed constant byte-identical. Extended to 500 accumulated clauses (`TAU_BA_COMPONENT_FACTORING=1`, `--block-max-splits 1`): sum of steps 463 s → 461 s, peak RSS 175 → 176 MB, output identical.

A small suite (`get_free_vars cache` in `test_tau_tree.cpp`) checks that answers read from the cache equal direct ones — binder subtraction at every level, sibling context, trimming and order — including the accumulating shape from #90. On a tree carrying this PR together with #96 and #97, the unit-test suite passes (443/443 with `TAU_BUILD_TESTS=ON`, plus the three new cases) and our own regression set — 19 gates, 27 hand-checked form classes, the 137-clause constitution run — is unchanged against 4ccdb1cd.

What remains at scale is the normalization of the accumulated constant itself, not this function — see #95; this PR does not try to address it.