### PR TITLE
Give the Tau-BA factoring helpers one declaration site

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TAU_HEADERS
 	boolean_algebras/sbf_ba.h
 	boolean_algebras/variant_ba.h
 	boolean_algebras/nso_ba.h
+	boolean_algebras/tau_ba_factoring.h
 	boolean_algebras/tau_ba.h
 	boolean_algebras/bv_ba.h
 	heuristics/bv_ba_simplification.h		# heuristic for simplifying boolean formulas with bitvectors

--- a/src/boolean_algebras/tau_ba.h
+++ b/src/boolean_algebras/tau_ba.h
@@ -14,6 +14,7 @@
 #define __IDNI__TAU__BOOLEAN_ALGEBRAS__TAU_BA_H__
 
 #include "tau_tree.h"
+#include "boolean_algebras/tau_ba_factoring.h"
 #include "splitter_types.h"
 #include "splitter.h"
 
@@ -23,13 +24,6 @@
 // bindings, etc... instead of tau,...
 
 namespace idni::tau_lang {
-
-/// Opt-in for support-component factoring of the Tau-BA constant/valid
-/// tests (`is_zero`/`is_one`; see the note in tau_ba.tmpl.h). Off by
-/// default; enabled via `api::set_ba_component_factoring(true)` or the
-/// environment variable TAU_BA_COMPONENT_FACTORING (a value of "0"
-/// disables).
-inline bool ba_component_factoring = false;
 
 // Check https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102609 to follow up on
 // the implementation of "Deducing this" on gcc.

--- a/src/boolean_algebras/tau_ba.tmpl.h
+++ b/src/boolean_algebras/tau_ba.tmpl.h
@@ -175,7 +175,7 @@ static bool cached_tau_ba_predicate(const tau_ba<BAs...>& fm,
  * @endinternal
  */
 template <typename node>
-static int factored_tau_units(tref fm, trefs& units) {
+int factored_tau_units(tref fm, trefs& units) {
 	using tau = tree<node>;
 	trefs clauses = get_cnf_wff_clauses<node>(fm);
 	for (size_t i = 0; i < clauses.size(); ++i) {
@@ -193,18 +193,10 @@ static int factored_tau_units(tref fm, trefs& units) {
 	return 0;
 }
 
-inline bool ba_component_factoring_enabled() {
-	static const bool env = [] {
-		const char* v = std::getenv("TAU_BA_COMPONENT_FACTORING");
-		return v && *v && !(v[0] == '0' && v[1] == '\0');
-	}();
-	return ba_component_factoring || env;
-}
-
 // Component-wise satisfiability; -1 = not applicable (fall back), 0 = unsat,
 // 1 = sat.
 template <typename node>
-static int factored_tau_sat(tref fm) {
+int factored_tau_sat(tref fm) {
 	using tau = tree<node>;
 	trefs units;
 	if (factored_tau_units<node>(fm, units) < 0) return -1;
@@ -274,7 +266,7 @@ static int factored_tau_sat(tref fm) {
 // Unit-wise validity (distributes over conjunction unconditionally);
 // -1 = not applicable, 0 = not valid, 1 = valid.
 template <typename node>
-static int factored_tau_valid(tref fm) {
+int factored_tau_valid(tref fm) {
 	using tau = tree<node>;
 	trefs units;
 	if (factored_tau_units<node>(fm, units) < 0) return -1;

--- a/src/boolean_algebras/tau_ba_factoring.h
+++ b/src/boolean_algebras/tau_ba_factoring.h
@@ -1,0 +1,54 @@
+/**
+ * @file tau_ba_factoring.h
+ * @brief Option and declarations for support-component factoring of the
+ * Tau-BA constant tests.
+ *
+ * Shared by `tau_ba.tmpl.h` (definitions) and `satisfiability.tmpl.h`
+ * (`simp_tau_unsat_valid` decides its per-path tests through these helpers),
+ * so neither side needs to forward-declare the other's functions or rely on a
+ * particular translation-unit layout.
+ */
+
+// To view the license please visit https://github.com/IDNI/tau-lang/blob/main/LICENSE.md
+
+#ifndef __IDNI__TAU__BOOLEAN_ALGEBRAS__TAU_BA_FACTORING_H__
+#define __IDNI__TAU__BOOLEAN_ALGEBRAS__TAU_BA_FACTORING_H__
+
+#include <cstdlib>
+
+#include "tau_tree.h"
+
+namespace idni::tau_lang {
+
+/// Opt-in for support-component factoring of the Tau-BA constant/valid
+/// tests (`is_zero`/`is_one`; see the note in tau_ba.tmpl.h). Off by
+/// default; enabled via `api::set_ba_component_factoring(true)` or the
+/// environment variable TAU_BA_COMPONENT_FACTORING (a value of "0"
+/// disables).
+inline bool ba_component_factoring = false;
+
+inline bool ba_component_factoring_enabled() {
+	static const bool env = [] {
+		const char* v = std::getenv("TAU_BA_COMPONENT_FACTORING");
+		return v && *v && !(v[0] == '0' && v[1] == '\0');
+	}();
+	return ba_component_factoring || env;
+}
+
+// Split a formula into its support-component units; -1 = not applicable.
+template <typename node>
+int factored_tau_units(tref fm, trefs& units);
+
+// Component-wise satisfiability; -1 = not applicable (fall back), 0 = unsat,
+// 1 = sat.
+template <typename node>
+int factored_tau_sat(tref fm);
+
+// Unit-wise validity (distributes over conjunction unconditionally);
+// -1 = not applicable, 0 = not valid, 1 = valid.
+template <typename node>
+int factored_tau_valid(tref fm);
+
+} // namespace idni::tau_lang
+
+#endif // __IDNI__TAU__BOOLEAN_ALGEBRAS__TAU_BA_FACTORING_H__

--- a/src/satisfiability.h
+++ b/src/satisfiability.h
@@ -15,6 +15,7 @@
 #define __IDNI__TAU__SATISFIABILITY_H__
 
 #include "tau_tree.h"
+#include "boolean_algebras/tau_ba_factoring.h"
 
 namespace idni::tau_lang {
 
@@ -198,13 +199,6 @@ bool are_tau_equivalent(tref f1, tref f2);
  * // not guarantee a particular normal form for the surviving disjuncts.
  * @endcode
  */
-// Support-component factoring (defined in boolean_algebras/tau_ba.tmpl.h,
-// same translation unit): used by simp_tau_unsat_valid below to decide its
-// per-path satisfiability tests unit-wise where that is exact.
-inline bool ba_component_factoring_enabled();
-template <typename node> static int factored_tau_sat(tref fm);
-template <typename node> static int factored_tau_valid(tref fm);
-
 template <NodeType node>
 tref simp_tau_unsat_valid(tref fm, const int_t start_time = 0,
 				const bool output = false);


### PR DESCRIPTION
Follow-up to the review note on #91: `satisfiability.h` forward-declared `factored_tau_sat`/`factored_tau_valid` as `static` templates that are defined in `tau_ba.tmpl.h`, which only holds together because `tau.h` is a single translation unit. This gives them one declaration site instead.

- new `boolean_algebras/tau_ba_factoring.h` with the `ba_component_factoring` option, `ba_component_factoring_enabled()` and the declarations of the three helpers (added to `TAU_HEADERS` so it lands in `tau.h`);
- `tau_ba.h` and `satisfiability.h` include it; the forward declarations and the option variable move out of them;
- the template definitions in `tau_ba.tmpl.h` drop `static`.

No behavioural change: on the run from #90 (142 steps, both switches on) every verdict and the printed constant are identical to 4ccdb1cd, and our full test set passes unchanged.