### PR TITLE
Do not re-collect the conjuncts of a conjunction at every nested `wff_and` in `syntactic_path_simplification`

### DIFF
--- a/src/heuristics/syntactic_path_simplification.h
+++ b/src/heuristics/syntactic_path_simplification.h
@@ -13,6 +13,8 @@
 #ifndef __IDNI__TAU__SYNTACTIC_PATH_SIMPLIFICATION_H__
 #define __IDNI__TAU__SYNTACTIC_PATH_SIMPLIFICATION_H__
 
+#include <unordered_set>
+
 namespace idni::tau_lang {
 
 /**

--- a/src/heuristics/syntactic_path_simplification.tmpl.h
+++ b/src/heuristics/syntactic_path_simplification.tmpl.h
@@ -72,9 +72,35 @@ template <NodeType node>
 tref syntactic_path_simplification_simplify_wff(tref root) {
 	using tau = tree<node>;
 	tref skip = nullptr;
-	auto down = [&skip](tref n) {
+	// A conjunction whose conjuncts yield no assignment cannot yield one
+	// at any nested wff_and of its own flattening either: their conjuncts
+	// are a subset. Mark those nested nodes done once, or the conjuncts
+	// of a k-chain get re-collected at each of its k spine nodes.
+	//
+	// Invariant this relies on: mark_spine visits exactly the wff nodes
+	// that get_cnf_wff_clauses (get_leaves along the wff_and spine)
+	// descends through, so a marked node's conjuncts are a subset of
+	// the marking node's. Both walk the same spine: a wff whose child
+	// is wff_and, then that wff_and's children. If one of them changes,
+	// the other must follow; the debug check below catches a drift.
+	std::unordered_set<tref> done;
+	auto mark_spine = [&done](auto&& self, tref m) -> void {
+		if (!tau::get(m).is(tau::wff)) return;
+		if (!tau::get(m)[0].is(tau::wff_and)) return;
+		if (!done.insert(m).second) return;
+		for (tref c : tau::get(m)[0].children()) self(self, c);
+	};
+	auto down = [&skip, &done, &mark_spine](tref n) {
 		// Skip intermediate nodes
 		if (!tau::get(n).is(tau::wff)) return n;
+		if (done.count(n)) {
+			// A marked node must yield no assumption: every conjunct
+			// of its flattening is a disjunction (the only conjuncts
+			// the loop below skips).
+			DBG(for (tref l : get_cnf_wff_clauses<node>(n))
+				assert(tau::get(l).child_is(tau::wff_or));)
+			return n;
+		}
 		const tau& t_n = tau::get(n)[0];
 		// Skip or
 		if (t_n.is(tau::wff_or))
@@ -91,6 +117,7 @@ tref syntactic_path_simplification_simplify_wff(tref root) {
 				assignments.emplace(tau::trim2(l), _F<node>());
 			else assignments.emplace( l, _T<node>());
 		}
+		if (assignments.empty()) mark_spine(mark_spine, n);
 		tref simp = rewriter::replace(n, assignments);
 		// If simp is false, current branch is not sat
 		if (tau::get(simp).equals_F()) {


### PR DESCRIPTION
Follow-up to #95, first of the two costs there.

`syntactic_path_simplification_simplify_wff` walks the formula in pre-order and, at every `wff_and`, collects the conjuncts of its flattening (`get_cnf_wff_clauses`) as `true`/`false` assumptions and substitutes them into the subtree. A conjunction of k clauses is a chain of k `wff_and` nodes, and the walk reaches every one of them: the conjuncts are collected k times, the i-th time over the k−i remaining ones. On the #95 run the walk collects 243 526 conjuncts per step at 500 accumulated clauses (~k²).

The change: when the conjuncts of a `wff_and` yield no assumption (every conjunct is a disjunction, as an implication in NNF is), the nested `wff_and` nodes of that same flattening cannot yield one either — their conjuncts are a subset — so they are marked done once and returned unchanged when the walk reaches them. Nothing else changes: with no assumptions there is no substitution, and the node was returned as it was before. Conjunctions that do yield assumptions are processed exactly as today.

Measured on the #95 run (500 clauses, `--block-max-splits 1`, `TAU_BA_COMPONENT_FACTORING=1`) against `main` @ 4ccdb1cd: sum of steps 463 s → 289 s (step 500 from 3 031 ms to 2 061 ms), conjuncts collected per step 243 526 → 4 117; together with #97 196 s. On the #90 script (default path) nothing changes, as the issue says. Output identical to `main` on every step; the unit-test suite passes (443/443, `TAU_BUILD_TESTS=ON`, on a tree carrying this PR together with #97 and the revised #93).