### PR TITLE
Memoise the temporal-layer normalisation of `tau_ba` constants per main tree

### DIFF
--- a/src/boolean_algebras/tau_ba.tmpl.h
+++ b/src/boolean_algebras/tau_ba.tmpl.h
@@ -15,7 +15,22 @@ template <typename... BAs>
 requires BAsPack<BAs...>
 static tref normalized_tau_ba_main(const tau_ba<BAs...>& fm) {
 	using node = typename tau_ba<BAs...>::node;
-	return normalize_temporal_quantifiers<node, false>(fm.nso_rr.main->get());
+	// Memoised per main tree: every Boolean operation on constants
+	// (~, &, |, +) normalises the temporal layer of its operands, and the
+	// same constants are operands over and over. Same key discipline as
+	// cached_tau_ba_predicate: the main tree identifies the element only
+	// when it carries no recurrence relations.
+	if (!fm.nso_rr.rec_relations.empty())
+		return normalize_temporal_quantifiers<node, false>(
+			fm.nso_rr.main->get());
+	using cache_t = subtree_unordered_map<node, tref>;
+	static cache_t& cache = tree<node>::template create_cache<cache_t>();
+	tref key = fm.nso_rr.main->get();
+	if (auto it = cache.find(key); it != cache.end()) return it->second;
+	// compute before emplace: normalisation can create new trees, and a
+	// rehash of `cache` must not happen with a half-built entry in it.
+	tref res = normalize_temporal_quantifiers<node, false>(key);
+	return cache.insert_or_assign(key, res).first->second;
 }
 
 template <typename... BAs>


### PR DESCRIPTION
Follow-up to #95, second of the two costs there.

`normalized_tau_ba_main` normalises the temporal layer of a constant's formula (`normalize_temporal_quantifiers`: DNF of the temporal layer, `reduce`, rebuild) and is called by the constant's Boolean operations — `~`, `&`, `|`, `+` — on their operands, every time. The same constants are operands over and over: on the #95 run the function runs 1 240 times per step regardless of the clause count, and each run is linear in the size of the accumulated constant.

The change memoises the result per main tree, with the discipline of `cached_tau_ba_predicate` (#93's neighbour): keyed by the main tree only when the element carries no recurrence relations (otherwise the tree is not a complete identity, and the function computes uncached as before), registered through `tree<node>`'s GC-aware cache registry so entries whose key does not survive a sweep are dropped, computed before emplaced. On the #95 run the memo misses twice per step.

Measured on the #95 run against `main` @ 4ccdb1cd: sum of steps 463 s → 368 s (step 500 from 3 031 ms to 1 625 ms); together with #96 196 s. Output identical to `main` on every step; the unit-test suite passes (443/443, `TAU_BUILD_TESTS=ON`, on a tree carrying this PR together with #96 and the revised #93).