### PR TITLE
Drop time-shifted conjunct copies from the always-continuation before boundary instantiation

### DIFF
--- a/src/satisfiability.tmpl.h
+++ b/src/satisfiability.tmpl.h
@@ -906,6 +906,123 @@ std::pair<tref, int_t> find_fixpoint_chi(tref chi_base, tref st,
  * @return @p fm with all non-initial IO variables made relative again.
  * @endinternal
  */
+/**
+ * @internal
+ * @brief Drop conjuncts that are exact time-shifted copies of another
+ * conjunct of @p fm.
+ *
+ * Justification: @p fm is used under an enclosing "always" from a start
+ * point s on. If D equals C shifted k>=1 steps further into the past,
+ * then for every t >= s+k the instance D(t) coincides with C(t-k), which
+ * "always C" already provides -- D adds nothing there. For t < s+k, D(t)
+ * reaches back across the start point into territory the specification
+ * never governed (only explicit initial conditions live there), so
+ * keeping D wrongly constrains that boundary. Removing exact shifted
+ * copies therefore only deletes implied conjuncts and corrects the
+ * boundary instantiation.
+ * A conjunct the specification itself carries as an explicit shifted
+ * clause must keep its (boundary-widening) meaning: an explicit C(t-1)
+ * next to C(t) governs one step below the start on purpose, and today's
+ * behaviour for it (usually F under an initial condition, since it
+ * constrains the input there) is the correct reading of that intent.
+ * The filter therefore groups the conjuncts of @p fm into classes of
+ * exact time-shifts of each other -- identified by their printed form
+ * re-based to a common newest time point, so the comparison is
+ * independent of the (per-stage, per-conjunct) time frame the pipeline
+ * happens to print them in -- and keeps, per class, as many members
+ * (newest first) as the user's own specification contributes to that
+ * class. Only the excess older members, which exist solely through the
+ * fixpoint's copying, are dropped; a class without any user-side anchor
+ * is left untouched, so a key mismatch degrades to today's verdict
+ * rather than to deleting a user-written clause.
+ * @param user_conjuncts The top-level conjuncts of the specification as
+ * it entered the fixpoint computation; their class multiplicities bound
+ * what may be dropped.
+ * @endinternal
+ */
+template <NodeType node>
+tref drop_shifted_conjunct_copies(tref fm, const trefs& user_conjuncts) {
+	using tau = tree<node>;
+	trefs cs = get_leaves<node>(fm, tau::wff_and);
+	if (cs.size() < 2) return fm;
+	trefs io = tau::get(fm).select_top(is_child<node, tau::io_var>);
+	if (get_max_shift<node>(io) <= 0) return fm;
+	// Base of a conjunct: the smallest [t-k] shift it references, i.e.
+	// how far its newest reference sits behind t. Conjuncts without IO
+	// variables or touching an absolute (initial) time point take no
+	// part in the classification and are never dropped.
+	auto base_of = [](tref c, trefs& cio_out) -> int_t {
+		cio_out = tau::get(c).select_top(is_child<node, tau::io_var>);
+		if (cio_out.empty()) return -1;
+		int_t b = -1;
+		for (tref v : cio_out) {
+			if (is_io_initial<node>(v)) return -1;
+			const int_t s = get_io_var_shift<node>(v);
+			if (b < 0 || s < b) b = s;
+		}
+		return b;
+	};
+	// Class key: the printed form of the conjunct re-based so that its
+	// newest reference sits at a fixed common shift. Printing after a
+	// uniform re-base makes two conjuncts compare equal exactly when one
+	// is a pure time-shift of the other, regardless of which time frame
+	// their stage of the pipeline printed them in. (Printed forms are
+	// required because the variable builders used by shift_io_vars_in_fm
+	// produce nodes that print identically to the fixpoint's own [t-k]
+	// variables but are not pointer-identical to them.)
+	std::vector<int_t> bases(cs.size(), -1);
+	int_t maxb = 0;
+	std::vector<trefs> cios(cs.size());
+	for (size_t i = 0; i < cs.size(); ++i) {
+		bases[i] = base_of(cs[i], cios[i]);
+		maxb = std::max(maxb, bases[i]);
+	}
+	std::vector<int_t> ubases(user_conjuncts.size(), -1);
+	std::vector<trefs> ucios(user_conjuncts.size());
+	for (size_t i = 0; i < user_conjuncts.size(); ++i) {
+		ubases[i] = base_of(user_conjuncts[i], ucios[i]);
+		maxb = std::max(maxb, ubases[i]);
+	}
+	auto key_of = [&maxb](tref c, const trefs& cio, int_t b) {
+		if (b == maxb) return TAU_TO_STR(c);
+		return TAU_TO_STR(shift_io_vars_in_fm<node>(c, cio, maxb - b));
+	};
+	std::map<std::string, int_t> user_mult;
+	for (size_t i = 0; i < user_conjuncts.size(); ++i)
+		if (ubases[i] >= 0) ++user_mult[key_of(
+			user_conjuncts[i], ucios[i], ubases[i])];
+	std::map<std::string, std::vector<size_t>> classes;
+	for (size_t i = 0; i < cs.size(); ++i)
+		if (bases[i] >= 0) classes[key_of(
+			cs[i], cios[i], bases[i])].push_back(i);
+	std::set<size_t> drop;
+	for (auto& [key, members] : classes) {
+		// Only drop within classes anchored in the user's own conjuncts.
+		// If key matching ever fails (a normalization changing a
+		// conjunct's printed shape between the collection point and
+		// here), the class counts zero user members and is left alone -
+		// the spec then answers as it did before this filter existed,
+		// instead of a mismatch deleting a clause the user wrote.
+		auto it = user_mult.find(key);
+		if (it == user_mult.end()) continue;
+		const size_t keep = std::max<size_t>((size_t) it->second, 1);
+		if (members.size() <= keep) continue;
+		// Keep the newest members; drop the older excess, but never a
+		// member sharing its base with a kept one.
+		std::stable_sort(members.begin(), members.end(),
+			[&](size_t a, size_t b) { return bases[a] < bases[b]; });
+		const int_t kept_base = bases[members[keep - 1]];
+		for (size_t m = keep; m < members.size(); ++m)
+			if (bases[members[m]] > kept_base)
+				drop.insert(members[m]);
+	}
+	if (drop.empty()) return fm;
+	trefs kept;
+	for (size_t i = 0; i < cs.size(); ++i)
+		if (!drop.contains(i)) kept.push_back(cs[i]);
+	return tau::build_wff_and(kept);
+}
+
 template <NodeType node>
 tref transform_back_non_initials(tref fm, const int_t highest_init_cond) {
 	using tau = tree<node>;
@@ -1201,6 +1318,11 @@ tref always_to_unbounded_continuation(tref fm, const int_t start_time,
 	io_vars = tau::get(tau::build_wff_and(fm, flag_initials))
 			.select_top(is_child<node, tau::io_var>);
 
+	// The specification's own top-level conjuncts (after the flag
+	// transformation, before the fixpoint): their shift-class
+	// multiplicities bound what the shift-copy filter below may drop.
+	trefs user_conjuncts = get_leaves<node>(fm, tau::wff_and);
+
 	// Save positions of io_variables which are initial conditions
 	std::set<std::pair<std::string, int_t>> initials;
 	for (int_t i = 0; i < (int_t) io_vars.size(); ++i)
@@ -1216,6 +1338,24 @@ tref always_to_unbounded_continuation(tref fm, const int_t start_time,
 
 	ubd_ctn = normalize_non_temp<node>(ubd_ctn);
 	ubd_ctn = transform_back_non_initials<node>(ubd_ctn, point_after_inits - 1);
+	// The fixpoint may return a conjunction that carries, next to a
+	// conjunct C over [t..t-k], an exact time-shifted copy of C one or
+	// more steps further back (guarded forms need one extra fixpoint
+	// step, and the extra step's older instance survives the
+	// back-translation as a [t-1]-shifted twin). Under the enclosing
+	// "always" the twin is redundant for every t past the start -- C at
+	// t-1 already follows from C holding at all earlier points -- but
+	// when the run below instantiates ubd_ctn AT the start point, the
+	// twin reaches one step BEFORE the start and constrains the input
+	// there: an accumulating-guard spec with an initial condition then
+	// reads unsatisfiable even though for every input a run exists.
+	// Dropping exact shifted copies removes only implied conjuncts and
+	// restores the boundary.
+	// Shifted twins can only arise from extra fixpoint steps; when the
+	// fixpoint stabilised immediately the continuation carries none, and
+	// skipping the filter keeps that (common) path untouched.
+	if (steps > 0) ubd_ctn = drop_shifted_conjunct_copies<node>(
+						ubd_ctn, user_conjuncts);
 
 	// Run phi_inf until all initial conditions are taken into account
 	io_vars = tau::get(ubd_ctn).select_top(is_child<node, tau::io_var>);

--- a/tests/integration/test_integration-interpreter.cpp
+++ b/tests/integration/test_integration-interpreter.cpp
@@ -1151,6 +1151,57 @@ TEST_SUITE("with inputs and outputs") {
 		CHECK ( !memory.value().empty() );
 	}
 
+	// Regression test: a guarded update with an initial condition is
+	// satisfiable but was reported unsat. The guarded two-clause split
+	// needs one extra fixpoint step, and the extra step's older instance
+	// survived the back-translation as a [t-1]-shifted twin of an
+	// existing conjunct; instantiated at the start point, the twin
+	// constrained the input one step before time 0 and for-all-inputs
+	// collapsed to F. The equation form of the same latch (next case)
+	// never had the problem: its fixpoint stabilises in zero steps.
+	TEST_CASE("guarded update with init is satisfiable") {
+		const char* sample = "(o1[0] = 0) && ((i1[t] = 1)"
+			" ? (o1[t] = o1[t-1] | 1) : (o1[t] = o1[t-1])).";
+		io_context<node_t> ctx;
+		strings i1_values = { "F", "T", "F" };
+		ctx.add_input("i1", tau_type_id<node_t>(),
+			std::make_shared<vector_input_stream>(i1_values));
+		auto memory = run_test(sample, ctx, 3);
+		REQUIRE ( memory.has_value() );
+		CHECK ( !memory.value().empty() );
+	}
+
+	// The equation form of the same latch, as the control for the case
+	// above: it must keep running unchanged.
+	TEST_CASE("equation form of the guarded latch runs") {
+		const char* sample = "(o1[0] = 0)"
+			" && (o1[t] = o1[t-1] | i1[t]).";
+		io_context<node_t> ctx;
+		strings i1_values = { "F", "T", "F" };
+		ctx.add_input("i1", tau_type_id<node_t>(),
+			std::make_shared<vector_input_stream>(i1_values));
+		auto memory = run_test(sample, ctx, 3);
+		REQUIRE ( memory.has_value() );
+		CHECK ( !memory.value().empty() );
+	}
+
+	// The mirror control for the fix: an EXPLICITLY written shifted
+	// clause next to its unshifted original deliberately governs one
+	// step below the start and stays boundary-constraining - with the
+	// init contradicting it at time 0 this spec is unsat today and must
+	// remain unsat (only fixpoint-created twins may be dropped, never a
+	// clause the specification itself carries).
+	TEST_CASE("deliberate shifted twin stays unsat") {
+		const char* sample = "(o1[0] = 0) && (o1[t] = i1[t])"
+			" && (o1[t-1] = i1[t-1]).";
+		io_context<node_t> ctx;
+		strings i1_values = { "T", "F" };
+		ctx.add_input("i1", tau_type_id<node_t>(),
+			std::make_shared<vector_input_stream>(i1_values));
+		auto memory = run_test(sample, ctx, 2);
+		CHECK ( (!memory.has_value() || memory.value().empty()) );
+	}
+
 	// Regression test: nested conditionals over a mix of `:tau` and `:bv[N]`
 	// streams reported "Internal error: Tau specification is unexpectedly
 	// unsat" at step 0 instead of producing a solution.


### PR DESCRIPTION
Fixes #100.

A minimal pair (`main` @ 3c24bad9, Release, defaults):

    (A) runs:   run (o2[0]:sbf = 0) && (o2[t]:sbf = o2[t-1]:sbf | i1[t]:sbf)
    (B) unsat:  run (o2[0]:sbf = 0) && ((i1[t]:sbf = 1) ? (o2[t]:sbf = o2[t-1]:sbf | 1)
                                                        : (o2[t]:sbf = o2[t-1]:sbf))

(B) is satisfiable - for every input a run exists - yet it reports "Tau specification is unsat",
with any initial value that the guarded branch can contradict (o2[0] = 1 happens to run; a bv[8]
guard behaves the same, so it is not sbf-specific). We ran into the shape while writing teaching
material - it was our first way to write a latch - and spent a while hunting the "contradiction"
in our own spec; the issue describes the affected class and how we got there.

Where it comes from: the guarded form needs one extra step in `find_fixpoint_phi` (the two-clause
split does not imply its shift in one `is_nso_impl` check) - which is fine in itself: inside the
telescope the extra slice sits at its absolute time point and is not redundant there. It is
`transform_back_non_initials` that loses the slice's lower validity bound, and the older instance
then survives as an exact `[t-1]`-shifted twin of a conjunct already in the continuation -
visible in the printed result of the un-initialised spec as
`(i1[t-1]:sbf' != 0 || o2[t-1]:sbf' = 0) && ...`. Under the enclosing always the twin is redundant for
every t past the start point (C at t-1 already follows from C holding at all earlier points), but
`always_to_unbounded_continuation`'s run loop instantiates the continuation AT the start point,
where the twin reaches one step further back and constrains the INPUT at time 0 - with
`o2[0] = 0` that forces `i1[0] != 1`, and for-all-inputs collapses to F.

The change, after the back-translation in `always_to_unbounded_continuation`:

* Conjuncts of the continuation are grouped into classes of exact time-shifts of each other, and
  each class keeps its newest members up to the number of conjuncts the specification itself (as
  it entered the fixpoint computation) contributes to that class; only the older excess - which
  exists solely through the fixpoint's copying - is dropped. The per-class count is what protects
  intent: an explicitly written C(t-1) next to C(t) contributes two members, stays intact, and
  keeps today's meaning (usually F under an initial condition, since it deliberately governs one
  step below the start and constrains the input there). Dropping only the fixpoint's excess
  removes implied conjuncts and restores the boundary, nothing else.
* Class membership is decided on the printed form of each conjunct after re-basing it to a common
  newest time point. The re-base matters: the pipeline does not keep one time frame per clause
  across stages (the same zero-lookback clause of one spec prints as `[t]` in the continuation
  and as `[t-1]` at an earlier stage), so any comparison anchored to absolute frames misfires;
  after the uniform re-base, two conjuncts compare equal exactly when one is a pure time-shift of
  the other. Printed forms are used at all because the variable builders behind
  `shift_io_vars_in_fm` produce nodes that print identically to the fixpoint's own `[t-k]`
  variables without being pointer-identical - if there is a canonical interning step I should use
  instead, happy to switch to it.
* The filter only runs when the fixpoint actually took extra steps (`steps > 0`) - the only way
  twins arise. A zero-step normalization therefore takes exactly the old code path: no key is
  built, nothing is shifted or printed, and byte- and cost-parity for that (common) case hold by
  construction. When the filter does run, its cost is one shift plus one print per conjunct, once
  per normalization - and it runs only on specs that previously answered unsat incorrectly, so
  there is no correct behaviour to slow down.

Measured (all on this box, Release):

* (B) now runs and behaves as the equation form does: a 3-input latch produces the expected
  0,0,1,1; the o2[0] = 1 variant and the bv[8]-guard variant run too. The un-initialised spec's
  printed normalization no longer carries the twin.
* The deliberate-boundary spec
  `run (o5[0]:sbf = 0) && (o5[t]:sbf = i5[t]:sbf) && (o5[t-1]:sbf = i5[t-1]:sbf)` still
  reports unsat, unchanged from `main` - its user-written twin is protected by the class count.
* (A) and every zero-step spec take the old code path by construction; (A)'s full output
  verified identical against the base commit.
* A 137-clause accumulating run (defaults plus `--block-max-splits 1`, single normalization,
  fixpoint stabilises in 0 steps): all 426 recorded stream assignments byte-identical to the
  same run on the base commit, and a per-assignment conjunct-multiset comparison (always-prefix
  normalised, disjuncts sorted) reports 0 differences - neither content nor conjunct ordering
  changes on specs the fix does not target. Wall/peak: 87.4 s / 76 MB (base) vs
  87.1 s / 76 MB (fix).
* Regression tests: three cases in the interpreter integration suite - the guarded latch
  (fails on the base commit, passes with the fix), its equation form, and the deliberate
  shifted twin that must stay unsat.
* Unit suite: 520/520 (ctest), Release and Debug, on the rebased branch.
