### PR TITLE
Accept a bare q/quit at a tuple-stream prompt as end of the run

### DIFF
--- a/src/repl_evaluator.tmpl.h
+++ b/src/repl_evaluator.tmpl.h
@@ -1591,11 +1591,21 @@ idni::diagnostics::result<int> repl_evaluator<BAs...>::eval(
 					return idni::diagnostics::result<int>(2);
 		auto req = *pending;
 		pending.reset();
-		if (!run_abort_ && req.kind == pending_request::stream_value)
-			req.stream->set(src);
+		// A tuple-typed console stream prompts for whole wire literals
+		// ({ ... }); a bare q/quit can never be one (req.type_tree is null
+		// exactly for tuple prompts -- see continue_running), so accept it
+		// as "end the run" here too. Without this, a piped script has no
+		// way to leave an always-constrained tuple run: q would be fed to
+		// the wire parser, rejected, and re-prompted until end-of-file.
+		// Plain streams are untouched -- there a bare q could be a value.
 		bool stop = run_abort_
-			|| (req.kind == pending_request::continue_or_quit
+			|| ((req.kind == pending_request::continue_or_quit
+				|| (req.kind == pending_request::stream_value
+					&& !req.type_tree))
 				&& (src == "q" || src == "quit"));
+		if (!run_abort_ && !stop
+			&& req.kind == pending_request::stream_value)
+			req.stream->set(src);
 		run_abort_ = false;
 		if (stop) finish_running();
 		else {


### PR DESCRIPTION
Fixes #101.

A tuple-typed console stream prompts for whole wire literals (`{ ... }`); a bare `q`/`quit` can
never be one, so the prompt now treats it the way the continue-or-quit prompt does. The
discriminator is already there: `pending_request.type_tree` is null exactly for tuple prompts
(a tuple literal is not a single BA type), so the change is three lines in
`repl_evaluator::eval` and plain streams are untouched -- there a bare `q` could be a
legitimate value, and still is (verified: a `bv[8]` console stream fed `q` still reports
"Failed to parse input value 'q'", unchanged).

Before, a piped script had no way to leave an always-constrained tuple run: the `q` was fed to
the wire parser, rejected with a retry, and re-prompted until end-of-file. Measured on the
reproducer from #101 (`main` @ 3c24bad9): before, `q` yields "ADT wire: Syntax Error:
Unexpected 'q'" twice and the run only ends at EOF; after, the run prints its step and ends with
a clean Quit. A bounded tuple run (three wire inputs, ends by itself) is byte-identical before
and after.

Unit suite: 520/520 (ctest), Release and Debug, with the branch rebased on current main.
