### PR TITLE
Keep the order atoms in the BDD-based DNF/CNF reduction

### DIFF
--- a/src/normal_forms.tmpl.h
+++ b/src/normal_forms.tmpl.h
@@ -828,8 +828,11 @@ auto lex_var_comp = [](tref x, tref y) {
  * @brief Predicate that classifies a wff node as a BDD variable.
  *
  * In BDD-based DNF/CNF reductions of well-formed formulas the following node
- * types are treated as atomic BDD variables: `bf_eq`, `wff_ref`, `wff_ex`,
- * `wff_sometimes`, `wff_always`, `wff_all`, and `constraint`.
+ * types are treated as atomic BDD variables: `bf_eq`, `bf_lt`, `bf_lteq`,
+ * `wff_ref`, `wff_ex`, `wff_sometimes`, `wff_always`, `wff_all`, and
+ * `constraint`. The order atoms count because a reduction that does not see
+ * them drops them: `b < 4 && 2 < b && (!b = 3 || a = 0)` would otherwise
+ * reduce to `!b = 3 || a = 0`.
  * @tparam node Tree node type.
  * @todo Extend for the full grammar.
  *
@@ -845,11 +848,14 @@ inline auto is_wff_bdd_var = [](tref n) {
 	using tau = tree<node>;
 	const auto& t = tau::get(n);
 	// `n` is a wff wrapper, so the invariant to check is on its child: the
-	// caller (dnf_cnf_to_reduced) establishes it with unequal_to_not_equal.
-	// Asserting `t.is(bf_neq)` instead would be vacuously true and check
-	// nothing.
+	// caller (dnf_cnf_to_reduced) establishes it with unequal_to_not_equal
+	// and order_atoms_to_literals. Asserting `t.is(bf_neq)` instead would be
+	// vacuously true and check nothing.
 	DBG(assert(!t.child_is(tau::bf_neq));)
+	DBG(assert(!t.child_is(tau::bf_nlt) && !t.child_is(tau::bf_nlteq));)
 	return t.child_is(tau::bf_eq)
+		|| t.child_is(tau::bf_lt)
+		|| t.child_is(tau::bf_lteq)
 		|| t.child_is(tau::wff_ref)
 		|| t.child_is(tau::wff_ex)
 		|| t.child_is(tau::wff_sometimes)
@@ -1339,6 +1345,7 @@ std::pair<std::vector<std::vector<int_t>>, trefs> dnf_cnf_to_reduced(tref fm,
 		// Substitute all sometimes by !always! and push inner equality in
 		fm = pre_order<node>(fm).apply_unique(smt_replace);
 		fm = unequal_to_not_equal<node>(fm);
+		fm = order_atoms_to_literals<node>(fm);
 	} else fm = apply_all_xor_def<node>(fm); // term case
 	trefs vars = is_wff ? tau::get(fm).select_top(is_wff_bdd_var<node>)
 			 : tau::get(fm).select_top(is_bf_bdd_var<node>);

--- a/src/normal_forms_transformations.h
+++ b/src/normal_forms_transformations.h
@@ -58,6 +58,22 @@ enum MemorySlotPost {
 template <NodeType node>
 tref unequal_to_not_equal(tref fm);
 
+/**
+ * @brief Rewrite the order atoms into literals over `<` and `<=`.
+ *
+ * Rewrites `$X !< $Y` into `!($X < $Y)`, `$X !<= $Y` into `!($X <= $Y)`,
+ * and the `>` / `>=` atoms (and their negations) into the swapped `<` /
+ * `<=` (negated) atoms, so that a formula only carries `bf_lt` and `bf_lteq`
+ * order atoms, possibly under `wff_neg`. The order-atom counterpart of
+ * unequal_to_not_equal, used by dnf_cnf_to_reduced to present the order
+ * atoms as BDD variables.
+ * @tparam node Tree node type.
+ * @param fm The formula to transform.
+ * @return Transformed formula with all order atoms as (negated) `bf_lt` / `bf_lteq`.
+ */
+template <NodeType node>
+tref order_atoms_to_literals(tref fm);
+
 
 /**
  * @brief Normalize an equality or disequality to the form `expr (!)= 0`.

--- a/src/normal_forms_transformations.tmpl.h
+++ b/src/normal_forms_transformations.tmpl.h
@@ -26,6 +26,34 @@ tref unequal_to_not_equal(tref fm) {
 	return result;
 }
 
+/** @internal @copydoc order_atoms_to_literals @endinternal */
+template <NodeType node>
+tref order_atoms_to_literals(tref fm) {
+	using tau = tree<node>;
+	DBG(LOG_TRACE << "order_atoms_to_literals/fm: " << LOG_FM(fm);)
+	auto to_literal = [](tref n) {
+		if (!tau::get(n).is(tau::wff)) return n;
+		const tau& c = tau::get(n)[0];
+		switch (c.value.nt) {
+		case tau::bf_nlt: return tau::build_wff_neg(
+			tau::build_bf_lt(c.first(), c.second()));
+		case tau::bf_nlteq: return tau::build_wff_neg(
+			tau::build_bf_lteq(c.first(), c.second()));
+		case tau::bf_gt: return tau::build_bf_lt(c.second(), c.first());
+		case tau::bf_gteq: return tau::build_bf_lteq(c.second(), c.first());
+		case tau::bf_ngt: return tau::build_wff_neg(
+			tau::build_bf_lt(c.second(), c.first()));
+		case tau::bf_ngteq: return tau::build_wff_neg(
+			tau::build_bf_lteq(c.second(), c.first()));
+		default: return n;
+		}
+	};
+	tref result = pre_order<node>(fm)
+				.apply_unique(to_literal, while_is_formula<node>);
+	DBG(LOG_TRACE << "order_atoms_to_literals/result: " << LOG_FM(result);)
+	return result;
+}
+
 // Convert X =(!=) Y to X + Y =(!=) 0
 /** @internal @copydoc norm_equation @endinternal */
 template<NodeType node>

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TESTS
 	bv_stress_check
 	ba_component_factoring
 	simp_tau_unsat_valid_unitwise
+	order_atoms_reduce
 )
 
 foreach(X IN LISTS TESTS)

--- a/tests/integration/test_integration-order_atoms_reduce.cpp
+++ b/tests/integration/test_integration-order_atoms_reduce.cpp
@@ -1,0 +1,80 @@
+// To view the license please visit https://github.com/IDNI/tau-lang/blob/main/LICENSE.md
+
+// The BDD-based DNF/CNF reduction (dnf_cnf_to_reduced) must keep the order
+// atoms `<` and `<=`: they are BDD variables like the equalities. Without
+// that, a bitvector variable pinned to one value by order atoms lost every
+// clause that mentioned only the pinned value, and
+// `ex x (x > 2 && x < 4 && (x = 3 -> a = 0))` normalized to T.
+
+#include "test_init.h"
+#include "test_tau_helpers.h"
+
+namespace {
+
+tref parse_wff(const std::string& sample) {
+	static tree<node_t>::get_options opts{ .parse = { .start = tree<node_t>::wff }};
+	auto src = tree<node_t>::get(sample, opts);
+	if (src == nullptr) TAU_LOG_ERROR << "Parsing failed for: " << sample;
+	return src;
+}
+
+std::string norm(const std::string& sample) {
+	auto wff = parse_wff(sample);
+	return wff ? tau::get(normalizer<node_t>(wff)).to_str() : "parse_error";
+}
+
+// Two samples normalize to the same formula, or to formulas whose
+// equivalence normalizes to T.
+bool same(const std::string& a, const std::string& b) {
+	tref ra = parse_wff(a), rb = parse_wff(b);
+	if (!ra || !rb) return false;
+	ra = normalizer<node_t>(ra), rb = normalizer<node_t>(rb);
+	if (tau::get(ra) == tau::get(rb)) return true;
+	return tau::get(normalizer<node_t>(tau::build_wff_equiv(ra, rb))).equals_T();
+}
+
+} // namespace
+
+TEST_SUITE("configuration") {
+	TEST_CASE("bdd_init") { bdd_init<Bool>(); }
+	TEST_CASE("logging") { logging::trace(); }
+}
+
+TEST_SUITE("order atoms survive the reduction") {
+
+	TEST_CASE("a value pinned by order atoms keeps the guarded consequent") {
+		// The interval (2, 4) of bv[4] holds exactly one value, 3, so the
+		// implication fires and only `a = 0` remains.
+		CHECK(same("ex x (x:bv[4] > { 2 }:bv[4] && x:bv[4] < { 4 }:bv[4] && (x:bv[4] = { 3 }:bv[4] -> a = 0))",
+			"a = 0"));
+		CHECK(same("ex x (x:bv[4] > { 2 }:bv[4] && x:bv[4] < { 4 }:bv[4] && (x:bv[4] = { 3 }:bv[4] -> y:bv[4] = { 0 }:bv[4]))",
+			"y:bv[4] = { 0 }:bv[4]"));
+		CHECK(same("ex x (x:bv[4] >= { 3 }:bv[4] && x:bv[4] <= { 3 }:bv[4] && (x:bv[4] = { 3 }:bv[4] -> a = 0))",
+			"a = 0"));
+		CHECK(same("ex x (x:bv[4] < { 1 }:bv[4] && (x:bv[4] = { 0 }:bv[4] -> a = 0))",
+			"a = 0"));
+		CHECK(same("ex x (x:bv[8] > { 2 }:bv[8] && x:bv[8] < { 4 }:bv[8] && (x:bv[8] = { 3 }:bv[8] -> a = 0))",
+			"a = 0"));
+	}
+
+	TEST_CASE("the same shapes without a guard are unchanged") {
+		CHECK(same("ex x (x:bv[4] > { 2 }:bv[4] && x:bv[4] < { 4 }:bv[4] && a = 0)", "a = 0"));
+		CHECK(norm("ex x (x:bv[4] > { 2 }:bv[4] && x:bv[4] < { 4 }:bv[4] && x:bv[4] != { 3 }:bv[4])") == "F");
+		CHECK(norm("ex x (x:bv[4] > { 2 }:bv[4] && x:bv[4] < { 4 }:bv[4] && (x:bv[4] != { 3 }:bv[4] || x:bv[4] = { 5 }:bv[4]))") == "F");
+		CHECK(same("ex x (x:bv[4] = { 3 }:bv[4] && (x:bv[4] = { 3 }:bv[4] -> a = 0))", "a = 0"));
+	}
+
+	TEST_CASE("negated order atoms are literals of the same variables") {
+		// `x !< 3` next to `x < 3` is a contradiction, not two unrelated atoms.
+		CHECK(norm("ex x (x:bv[4] < { 3 }:bv[4] && !(x:bv[4] < { 3 }:bv[4]))") == "F");
+		CHECK(norm("all x (x:bv[4] < { 3 }:bv[4] || !(x:bv[4] < { 3 }:bv[4]))") == "T");
+		CHECK(norm("all x (x:bv[4] <= { 3 }:bv[4] || x:bv[4] > { 3 }:bv[4])") == "T");
+		CHECK(same("ex x (!(x:bv[4] < { 1 }:bv[4]) && !(x:bv[4] > { 1 }:bv[4]) && (x:bv[4] = { 1 }:bv[4] -> a = 0))",
+			"a = 0"));
+	}
+
+	TEST_CASE("universal form of the pinned value") {
+		CHECK(same("all x ((x:bv[4] > { 2 }:bv[4] && x:bv[4] < { 4 }:bv[4]) -> (x:bv[4] = { 3 }:bv[4] -> a = 0))",
+			"a = 0"));
+	}
+}


### PR DESCRIPTION
Fixes #105.

`dnf_cnf_to_reduced` picks the BDD variables of a formula with `is_wff_bdd_var`, which admits
`bf_eq` and the quantifier, reference and constraint nodes but not `bf_lt` or `bf_lteq`.
`clause_to_vector` then skips every literal it has no variable for, so a reduction over a
formula with order atoms silently drops them. The reducing `to_dnf` is what
`complete_quantifier_elimination` distributes with, and a bitvector block whose Boole
decomposition cannot pivot (bitvector atoms are reserved for blasting) reaches it with the order
atoms still in place: for `ex x (x > 2 && x < 4 && (x = 3 -> a = 0))` the block
`b1 < {4} && {2} < b1 && (!b1 = {3} || a = 0)` comes back from `to_dnf` as
`b1 != {3} || a = 0`, and `ex b1 (b1 != 3)` is T - the consequent is gone (#105).

The change:

* `is_wff_bdd_var` admits `bf_lt` and `bf_lteq`, so the order atoms are BDD variables like the
  equalities.
* After `push_negation_in` a negated order atom is its own node kind (`bf_nlt`, `bf_nlteq`), not a
  `wff_neg` over the positive atom, so admitting the two positive kinds alone would still lose
  the negated ones. `order_atoms_to_literals`, the order-atom counterpart of
  `unequal_to_not_equal`, rewrites `!<` and `!<=` into `!(<)` and `!(<=)` (and `>`, `>=` and their
  negations into the swapped `<`, `<=`) right after `unequal_to_not_equal` in
  `dnf_cnf_to_reduced`; the debug assertion in `is_wff_bdd_var` now also covers `bf_nlt` and
  `bf_nlteq`.

Nothing else moves: a formula without order atoms sees the same variables as before, and the
reduced formula is rebuilt from the same paths. The rewrite is a presentation step inside the
reduction, undone by the `push_negation_in` that closes `reduce`.

Checks (Release, `main` @ 1c1e58ae vs this branch):

* the six lines of #105: `T`, `a = 0`, `F`, `F`, `T`, `T` before; `a = 0`, `a = 0`, `F`,
  `F`, `y = 0`, `a = 0` after;
* two long `run`s over specs with bitvector commands and results (141 steps of a 137-clause
  step spec, and a 500-step accumulating one; `--block-max-splits 1`): every verdict and every
  output-stream line identical before and after; 11.9 s vs 11.9 s and 177 s vs 182 s wall,
  peak RSS 52 MB vs 52 MB and 147 MB vs 149 MB; a 19-block regression battery over the same
  engine, times per block within 1 s of the unpatched build;
* `test_integration-order_atoms_reduce` (new, 6 cases, 14 checks): a value pinned by order atoms keeps
  the guarded consequent (bv[4] and bv[8], `>`/`<` and `>=`/`<=`, the bottom value via `< 1`,
  and the universal form); the same shapes without a guard are unchanged; negated order atoms are
  literals of the same variables (`x < 3 && !(x < 3)` is F, `x <= 3 || x > 3` is T);
* full suites on this branch: Release 521/521, Debug 521/521.

One thing worth a look in review: `order_atoms_to_literals` maps `>` and `>=` to the swapped `<`
and `<=` so both spellings share one variable. `boole_normal_form` applies the same mapping
through `normalize_atomic_formula_operators` before its own decomposition, so on the normalizer
path those cases are usually gone by the time `reduce` runs; the rewrite here keeps the
reduction correct for callers that reach it with the raw spellings.