### PR TITLE
Add an opt-in test-point elimination for quantified bitvector variables compared only against constants

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -261,6 +261,10 @@ struct api {
 	/// Enable/disable support-component factoring of the Tau-BA
 	/// constant/valid tests (tau_ba.tmpl.h). Off by default.
 	static void set_ba_component_factoring(bool state);
+	/// Enable/disable the test-point elimination of quantified bitvector
+	/// variables compared only against constants (normalizer.tmpl.h). Off by
+	/// default.
+	static void set_bv_case_split(bool state);
 	/** @brief Enable/disable ANSI colour highlighting in output. */
 	static void set_highlighting(bool state);
 	/** @brief Enable/disable JSON output mode. */

--- a/src/api.tmpl.h
+++ b/src/api.tmpl.h
@@ -170,6 +170,11 @@ void api<node>::set_ba_component_factoring(bool state) {
 }
 
 template <NodeType node>
+void api<node>::set_bv_case_split(bool state) {
+	bv_case_split = state;
+}
+
+template <NodeType node>
 void api<node>::set_highlighting(bool highlighting) {
 	pretty_printer_highlighting = highlighting;
 }

--- a/src/normalizer.h
+++ b/src/normalizer.h
@@ -27,6 +27,21 @@
 
 namespace idni::tau_lang {
 
+/// Opt-in for the test-point elimination of quantified bitvector variables
+/// that occur only in comparisons against constants (see
+/// `bv_case_split_quantifiers` in normalizer.tmpl.h). Off by default; enabled via
+/// `api::set_bv_case_split(true)` or the environment variable
+/// TAU_BV_CASE_SPLIT (a value of "0" disables).
+inline bool bv_case_split = false;
+
+inline bool bv_case_split_enabled() {
+	static const bool env = [] {
+		const char* v = std::getenv("TAU_BV_CASE_SPLIT");
+		return v && *v && !(v[0] == '0' && v[1] == '\0');
+	}();
+	return bv_case_split || env;
+}
+
 /**
  * @brief Normalize a Tau formula, handling both temporal and non-temporal cases.
  *

--- a/src/normalizer.tmpl.h
+++ b/src/normalizer.tmpl.h
@@ -141,9 +141,211 @@ tref scope_out_independent_conjuncts(tref fm) {
  * @endcode
  * @endinternal
  */
+// Test-point elimination of a quantified bitvector variable v that occurs
+// only in comparisons (`=`, `!=`, `<`, `<=`, `>`, `>=`, possibly negated)
+// against constants c_1 < ... < c_k of its own type.
+//
+// Over the unsigned, finite bitvector order every such atom changes its value
+// only at a c_i, so phi is constant on each cell the c_i cut the domain into
+// -- every c_i on its own, and the open intervals below c_1, between
+// consecutive c_i, and above c_k -- and one witness per non-empty cell
+// decides it:
+//
+//     ex v phi   ==   \/ over cells  phi[v := witness(cell)]
+//     all v phi  ==   /\ over cells  phi[v := witness(cell)]
+//
+// When v is only ever tested for equality, all interval cells agree (every
+// test is false there) and a single complement witness stands for them:
+// k + 1 instances instead of at most 2k + 1. This is the finite-domain form
+// of test-point elimination (Cooper / Ferrante-Rackoff), an identity on the
+// formula; the substituted tests fold to T/F in the normalization that
+// follows, which is what makes the instances cheap.
+//
+// The same identity holds for symbolic bounds t_i (test points 0, t_i and
+// t_i + 1), but its instances then carry `t_i + 1` arithmetic and atoms such
+// as `t + 1 = t` that the normalization does not decide, so they would be
+// handed to blasting -- the path this pass exists to avoid. Measured on the
+// integration tests: such instances come back as residues, not as T/F. The
+// symbolic case is therefore left to the existing pipeline.
+//
+// Why it is here: a conditional over a bitvector command, `i[t] = c ? A : B`,
+// desugars to `(i[t] != c || A) && (i[t] = c || B)` -- the guard in both
+// polarities. When the interpreter closes a boundary step it quantifies such
+// commands and result codes, and bitvector atoms are reserved for blasting and
+// the solver, so the Boole decomposition splits on the remaining atomless
+// equalities and carries every guard unchanged into both branches of every
+// split. Eliminating the tested variable first lets the guards fold before
+// any block is formed.
+//
+// Structural criterion only: any other occurrence of v (inside a term, a
+// comparison with a non-constant, both sides of one atom, a nested binder of
+// the same variable), or a variable of a foreign type, leaves the quantifier
+// to the existing pipeline untouched. A cell exists for every tested
+// constant, so the domain is never exhausted and no width limit is needed.
+namespace bv_case_split_detail {
+
+// Base-2 digits of the bitvector constant in `c`, left-padded to `width`.
+template <NodeType node>
+std::optional<std::string> bits_of(tref c, size_t width) {
+	auto cte = std::get<bv>(tree<node>::get(c).get_ba_constant());
+	if (!cte.isBitVectorValue()) return std::nullopt;
+	std::string s = cte.getBitVectorValue();
+	if (s.size() > width) return std::nullopt;
+	return std::string(width - s.size(), '0') + s;
+}
+
+// Successor of a padded base-2 string; nullopt on overflow (all ones).
+inline std::optional<std::string> succ(std::string s) {
+	for (size_t i = s.size(); i-- > 0;) {
+		if (s[i] == '0') { s[i] = '1'; return s; }
+		s[i] = '0';
+	}
+	return std::nullopt;
+}
+
+} // namespace bv_case_split_detail
+
+template <NodeType node>
+tref bv_case_split_quantifiers(tref formula) {
+	using tau = tree<node>;
+	using namespace bv_case_split_detail;
+	auto is_comparison = [](const tau& atom) {
+		switch (atom.value.nt) {
+			case tau::bf_eq: case tau::bf_neq:
+			case tau::bf_lt: case tau::bf_lteq:
+			case tau::bf_gt: case tau::bf_gteq:
+			case tau::bf_nlt: case tau::bf_nlteq:
+			case tau::bf_ngt: case tau::bf_ngteq:
+				return true;
+			default: return false;
+		}
+	};
+	auto is_order = [](const tau& atom) {
+		return atom.value.nt != tau::bf_eq && atom.value.nt != tau::bf_neq;
+	};
+	auto step = [&](tref n) -> tref {
+		if (!is_child_quantifier<node>(n)) return n;
+		const tau& t = tau::get(n);
+		const tref var = t[0].first();
+		const tref scope = t[0].second();
+		const size_t vtype = tau::get(var).get_ba_type();
+		if (vtype == 0 || !is_bv_type_family<node>(vtype)) return n;
+		const size_t width = get_bv_width<node>(vtype);
+		if (width == 0) return n;
+		// Scan: every occurrence of `var` must be one side of a comparison
+		// whose other side is a constant of the same type. BA constants are
+		// opaque and not descended into.
+		std::vector<tref> occ;
+		std::vector<tref> tests;   // the tested constants (term nodes), deduplicated
+		bool ok = true, any_order = false;
+		std::vector<tref> st{scope};
+		while (!st.empty() && ok) {
+			tref x = st.back(); st.pop_back();
+			if (!x) continue;
+			const tau& tx = tau::get(x);
+			if (tx.is_ba_constant()) continue;
+			// A nested binder of the same variable: its occurrences are
+			// structurally identical to the free ones and would be
+			// substituted with them. Decline rather than capture.
+			if (is_child_quantifier<node>(x)
+				&& tau::get(tx[0].first()) == tau::get(var)) { ok = false; break; }
+			if (tx.is(tau::wff) && is_comparison(tx[0])) {
+				const tau& atom = tx[0];
+				tref l = atom[0][0].get(), r = atom[1][0].get();
+				const bool lv = tau::get(l) == tau::get(var);
+				const bool rv = tau::get(r) == tau::get(var);
+				if (lv || rv) {
+					if (lv && rv) { ok = false; break; }
+					tref other = lv ? r : l;
+					if (!tau::get(other).is_ba_constant()
+						|| tau::get(other).get_ba_type() != vtype) { ok = false; break; }
+					occ.push_back(lv ? l : r);
+					if (is_order(atom)) any_order = true;
+					bool seen = false;
+					for (tref c : tests)
+						if (tau::get(c) == tau::get(other)) { seen = true; break; }
+					if (!seen) tests.push_back(other);
+					continue;
+				}
+			}
+			if (tau::get(x) == tau::get(var)) { ok = false; break; }
+			for (tref c : tx.children()) st.push_back(c);
+		}
+		if (!ok || occ.empty()) return n;
+		auto constant_of = [&](const std::string& bits) -> tref {
+			typename node::constant cte = {make_bitvector_value(width, bits)};
+			return tau::get_ba_constant(cte, vtype);
+		};
+		const std::string zero(width, '0');
+		std::vector<tref> witnesses;
+		// Known cells: sort the constants, then each of them and one value per
+		// non-empty interval (a single complement value when no order atom
+		// occurs -- all intervals agree then).
+		std::vector<std::pair<std::string, tref>> tested;
+		for (tref c : tests) {
+			auto bits = bits_of<node>(c, width);
+			if (!bits) return n;
+			tested.emplace_back(*bits, c);
+		}
+		std::sort(tested.begin(), tested.end(),
+			[](const auto& a, const auto& b) { return a.first < b.first; });
+		for (const auto& [_, c] : tested) witnesses.push_back(c);
+		std::vector<std::string> gaps;
+		if (tested.front().first != zero) gaps.push_back(zero);
+		for (size_t i = 0; i + 1 < tested.size(); ++i) {
+			auto s = succ(tested[i].first);
+			if (s && *s < tested[i + 1].first) gaps.push_back(*s);
+		}
+		if (auto s = succ(tested.back().first); s) gaps.push_back(*s);
+		if (!any_order && !gaps.empty()) gaps.resize(1);
+		for (const auto& g : gaps) witnesses.push_back(constant_of(g));
+		// Miniscoping before instantiating: only the part of the scope that
+		// mentions `var` is instantiated per cell. For either quantifier,
+		// Q v (A(v) && B) == (Q v A) && B and Q v (A(v) || B) == (Q v A) || B
+		// when B does not contain v, so an independent conjunct or disjunct is
+		// attached once, outside the case analysis, instead of being copied
+		// into every cell (a scope carrying heavy content about other
+		// variables would otherwise multiply that content by the cell count).
+		const bool is_ex = t.child_is(tau::wff_ex);
+		auto instance = [&](tref body, tref w) -> tref {
+			subtree_map<node, tref> changes;
+			for (tref o : occ) changes[o] = w;
+			return rewriter::replace<node>(body, changes);
+		};
+		auto cases = [&](tref body) -> tref {
+			tref res = nullptr;
+			for (tref w : witnesses) {
+				tref inst = instance(body, w);
+				res = !res ? inst : is_ex ? tau::build_wff_or(res, inst)
+					: tau::build_wff_and(res, inst);
+			}
+			return res;
+		};
+		auto eliminate = [&](auto& self, tref body) -> tref {
+			if (!contains<node>(body, var)) return body;
+			const tau& tb = tau::get(body);
+			if (tb.is(tau::wff) && (tb.child_is(tau::wff_and) || tb.child_is(tau::wff_or))) {
+				tref l = tb[0].first(), r = tb[0].second();
+				const bool lv = contains<node>(l, var), rv = contains<node>(r, var);
+				if (lv != rv) {
+					tref dep = self(self, lv ? l : r), ind = lv ? r : l;
+					return tb.child_is(tau::wff_and)
+						? tau::build_wff_and(dep, ind)
+						: tau::build_wff_or(dep, ind);
+				}
+			}
+			return cases(body);
+		};
+		return eliminate(eliminate, scope);
+	};
+	auto visit = [](tref x) { return while_is_formula<node>(x); };
+	return post_order<node>(formula).apply_unique(step, visit);
+}
+
 template <NodeType node>
 tref eliminate_bv_and_quantifiers(tref form) {
 	using tau = tree<node>;
+	if (bv_case_split_enabled()) form = bv_case_split_quantifiers<node>(form);
 
 	// Before anything blasts or decomposes: a foreign-typed sibling conjunct
 	// inside a bitvector quantifier's scope makes the whole scope fail

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TESTS
 	bv_stress_check
 	ba_component_factoring
 	simp_tau_unsat_valid_unitwise
+	bv_case_split
 )
 
 foreach(X IN LISTS TESTS)

--- a/tests/integration/test_integration-bv_case_split.cpp
+++ b/tests/integration/test_integration-bv_case_split.cpp
@@ -1,0 +1,146 @@
+// To view the license please visit https://github.com/IDNI/tau-lang/blob/main/LICENSE.md
+
+// Test-point elimination of quantified bitvector variables compared only
+// against constants (normalizer.tmpl.h, opt-in). The split is an identity on the
+// formula, so normalization with the split enabled must agree with the
+// pipeline without it -- both where the split applies and where it must
+// decline (arithmetic occurrence; a tested set covering the whole domain).
+
+#include "test_integration-interpreter_helper.h"
+
+namespace {
+
+struct split_config {
+	split_config(bool on) { bv_case_split = on; }
+	~split_config() { bv_case_split = false; }
+};
+
+tref parse_wff(const std::string& sample) {
+	static tree<node_t>::get_options opts{ .parse = { .start = tree<node_t>::wff }};
+	auto src = tree<node_t>::get(sample, opts);
+	if (src == nullptr) TAU_LOG_ERROR << "Parsing failed for: " << sample;
+	return src;
+}
+
+tref normalized(const std::string& sample, bool on) {
+	split_config c(on);
+	auto wff = parse_wff(sample);
+	return wff ? normalizer<node_t>(wff) : nullptr;
+}
+
+std::string norm(const std::string& sample, bool on) {
+	tref r = normalized(sample, on);
+	return r ? tau::get(r).to_str() : "parse_error";
+}
+
+// Same verdict with and without the split: equal normal forms, or -- when the
+// two pipelines pick different but equivalent spellings -- an equivalence of
+// the two result trees that normalizes to T.
+bool agree(const std::string& sample) {
+	tref off = normalized(sample, false), on = normalized(sample, true);
+	if (!off || !on) return false;
+	if (tau::get(off) == tau::get(on)) return true;
+	split_config c(false);
+	return tau::get(normalizer<node_t>(tau::build_wff_equiv(off, on))).equals_T();
+}
+
+strings run_command_spec(bool on) {
+	split_config c(on);
+	bdd_init<Bool>();
+	// A conditional over a bitvector command with a lookback and an initial
+	// condition: the boundary step quantifies the future command universally
+	// and the future outputs existentially, which is where the split applies.
+	auto spec = create_spec(
+		"(o1[0] = 0) && (i1[t] = { 1 }:bv[2] ? o1[t] = o1[t-1] : o1[t] = o1[t-1]').");
+	io_context<node_t> ctx;
+	strings i1_values = { "1", "2", "1", "0" };
+	ctx.add_input("i1", bv_type_id<node_t>(2),
+		std::make_shared<vector_input_stream>(i1_values));
+	auto o1 = std::make_shared<vector_output_stream>();
+	ctx.add_output("o1", tau_type_id<node_t>(), o1);
+	auto maybe_i = run<node_t>(spec, ctx, 4);
+	REQUIRE(maybe_i.has_value());
+	return o1->get_values();
+}
+
+} // namespace
+
+TEST_SUITE("configuration") {
+	TEST_CASE("bdd_init") { bdd_init<Bool>(); }
+	TEST_CASE("logging") { logging::trace(); }
+}
+
+TEST_SUITE("bv case split") {
+
+	TEST_CASE("existential over a tested command") {
+		CHECK(agree("ex x ((x:bv[8] = { 1 }:bv[8] && a = 0) || (x:bv[8] != { 1 }:bv[8] && b = 0))"));
+		CHECK(norm("ex x ((x:bv[8] = { 1 }:bv[8] && a = 0) || (x:bv[8] != { 1 }:bv[8] && b = 0))", true)
+			== norm("a = 0 || b = 0", true));
+	}
+
+	TEST_CASE("universal over a tested command") {
+		CHECK(agree("all x (x:bv[8] = { 1 }:bv[8] || a = 0)"));
+		CHECK(norm("all x (x:bv[8] = { 1 }:bv[8] || a = 0)", true) == norm("a = 0", true));
+	}
+
+	TEST_CASE("two tested constants, both polarities") {
+		CHECK(agree("ex x ((x:bv[8] = { 1 }:bv[8] || a = 0) && (x:bv[8] = { 2 }:bv[8] || b = 0) && (x:bv[8] != { 1 }:bv[8] || c = 0))"));
+	}
+
+	TEST_CASE("order tests cut the domain into cells") {
+		// x must be 3: the interval (2, 4) has exactly one value, so the
+		// implication fires and the formula is `a = 0`. (Not compared against
+		// the pipeline without the switch here: on this shape -- a negated
+		// equality next to order atoms that pin the variable -- it currently
+		// normalizes to T, dropping the consequent; reported separately.)
+		CHECK(norm("ex x (x:bv[4] > { 2 }:bv[4] && x:bv[4] < { 4 }:bv[4] && (x:bv[4] = { 3 }:bv[4] -> a = 0))", true)
+			== norm("a = 0", true));
+		CHECK(agree("ex x (x:bv[4] > { 2 }:bv[4] && x:bv[4] < { 4 }:bv[4] && a = 0)"));
+		CHECK(norm("all x (x:bv[4] < { 3 }:bv[4] || x:bv[4] >= { 3 }:bv[4])", true) == "T");
+		CHECK(norm("ex x (x:bv[4] < { 2 }:bv[4] && x:bv[4] > { 5 }:bv[4])", true) == "F");
+		CHECK(norm("ex x (x:bv[4] <= { 2 }:bv[4] && x:bv[4] != { 0 }:bv[4] && x:bv[4] != { 1 }:bv[4] && x:bv[4] != { 2 }:bv[4])", true) == "F");
+		// Boundary cells at both ends of the domain.
+		CHECK(norm("all x (x:bv[2] = { 0 }:bv[2] || x:bv[2] > { 0 }:bv[2])", true) == "T");
+		CHECK(norm("ex x (x:bv[2] > { 3 }:bv[2])", true) == "F");
+	}
+
+	TEST_CASE("independent parts are not multiplied") {
+		// The conjunct about y does not mention x and must come out once.
+		CHECK(agree("ex x (x:bv[4] = { 1 }:bv[4] && y:bv[4] + { 1 }:bv[4] = { 3 }:bv[4])"));
+		CHECK(norm("ex x ((x:bv[4] = { 1 }:bv[4] || a = 0) && b = 0)", true)
+			== norm("b = 0", true));
+		CHECK(norm("all x ((x:bv[4] = { 1 }:bv[4] && a = 0) || b = 0)", true)
+			== norm("b = 0", true));
+	}
+
+	TEST_CASE("declines on a comparison with a non-constant") {
+		// A symbolic bound is left to the pipeline: same verdict either way.
+		CHECK(agree("ex x (x:bv[4] = y:bv[4] && (x:bv[4] = { 1 }:bv[4] -> a = 0))"));
+		CHECK(norm("all x (x:bv[4] = { 2 }:bv[4] || x:bv[4] != y:bv[4] || a = 0)", true)
+			== norm("all x (x:bv[4] = { 2 }:bv[4] || x:bv[4] != y:bv[4] || a = 0)", false));
+	}
+
+	TEST_CASE("declines on a nested binder of the same variable") {
+		// The inner x must not be substituted with the outer one.
+		CHECK(agree("ex x (x:bv[4] = { 1 }:bv[4] && all x:bv[4] (x:bv[4] = { 1 }:bv[4] || a = 0))"));
+		CHECK(norm("ex x (x:bv[4] = { 1 }:bv[4] && all x:bv[4] (x:bv[4] = { 1 }:bv[4] || a = 0))", true)
+			== norm("a = 0", true));
+	}
+
+	TEST_CASE("declines on an arithmetic occurrence") {
+		CHECK(agree("ex x (x:bv[4] = { 3 }:bv[4] && x:bv[4] + { 5 }:bv[4] = { 8 }:bv[4])"));
+		CHECK(norm("ex x (x:bv[4] = { 3 }:bv[4] && x:bv[4] + { 5 }:bv[4] = { 8 }:bv[4])", true) == "T");
+	}
+
+	TEST_CASE("a tested set covering the domain leaves no interval cell") {
+		CHECK(agree("all x (x:bv[1] = { 0 }:bv[1] || x:bv[1] = { 1 }:bv[1])"));
+		CHECK(norm("all x (x:bv[1] = { 0 }:bv[1] || x:bv[1] = { 1 }:bv[1])", true) == "T");
+		CHECK(norm("ex x (x:bv[1] != { 0 }:bv[1] && x:bv[1] != { 1 }:bv[1])", true) == "F");
+	}
+
+	TEST_CASE("run outputs are unchanged with the split enabled") {
+		auto off = run_command_spec(false);
+		auto on = run_command_spec(true);
+		CHECK(off == on);
+	}
+}


### PR DESCRIPTION
Addresses #107.

The shape (`main` @ 1c1e58ae, Release): a `run` with initial conditions whose step spec is a nested
conditional over a bitvector command, assigning a bitvector result code - the script in #107.
With `--block-max-splits 1` its first step takes 0.11 s; the budget is what keeps that step from
building a residue the enclosing block cannot distribute, and the first step depends on it
entirely (the curve is in the issue).

Where it comes from: at the boundary step `get_ubt_ctn_at` closes the spec over the future
command (universally) and the future outputs (existentially). The conditional desugars to guard
implications, so each guard atom appears in both polarities; the Boole decomposition cannot pivot
on bitvector atoms and carries every guard into both branches of every split, and the enclosing
block's last-resort elimination then distributes the residue into a DNF whose clause product
overflows. The budget avoids this by re-wrapping the inner block early; this change removes the
guards from the block's path instead, so the verdict no longer rests on the parameter on this
class - and with the parameter it still halves the step.

The change, at the entry of `eliminate_bv_and_quantifiers`, behind an opt-in switch:

* A quantified bitvector variable that occurs only in comparisons (`=`, `!=`, `<`, `<=`, `>`,
  `>=`, possibly under a negation) against constants of its own type is replaced by the case
  analysis over the cells its tested constants cut the unsigned domain into: every tested
  constant on its own, and one witness for each non-empty open interval below, between and above
  them (a single complement witness when only equality tests occur, since all intervals agree
  then):

      ex v phi   ==   \/ over cells  phi[v := witness(cell)]
      all v phi  ==   /\ over cells  phi[v := witness(cell)]

* The reason this cannot change an answer: over the unsigned, finite bitvector order every atom
  that mentions `v` changes its value only at a tested constant, so `phi` is constant on each
  cell, and one value per cell decides it. This is the finite-domain form of test-point
  elimination (the Cooper / Ferrante-Rackoff idea over an unsigned bitvector order), an identity
  on the formula. The substituted tests fold to T/F in the normalization that follows, so no
  guard reaches the decomposition in both polarities - and that folding is what makes the
  instances cheap.
* Why constants and not arbitrary bounds: the same identity holds for symbolic bounds `t` (test
  points `0`, `t`, `t + 1`), and we had it implemented, but its instances carry `t + 1`
  arithmetic and atoms such as `t + 1 = t` that the normalization does not decide - on the
  integration tests they came back as residues (`y+1 !< y || y !<= y+1` for a tautology), which
  would then be handed to blasting, the path this pass exists to avoid. So the symbolic case is
  deliberately left to the pipeline; if there is a canonical bitvector simplification step such
  residues should go through, the extension is a few lines.
* The scope is miniscoped first - `Q v (A(v) && B) == (Q v A) && B` and `Q v (A(v) || B) ==
  (Q v A) || B` for `B` without `v`, for either quantifier - so only the part that mentions the
  variable is instantiated per cell; content about other variables (the arithmetic of a sibling
  quantifier's variable, say) is attached once and never multiplied by the cell count.
* Purely structural, no size heuristic: a variable with any other occurrence (inside a term, a
  comparison with a non-constant, both sides of one atom, a nested binder of the same variable)
  is left to the existing pipeline untouched; a cell exists for every tested constant, so the
  domain is never exhausted and no width limit is needed. Cost: at most 2k + 1 instances of the
  dependent part for k tested constants (k + 1 with equality tests only), each folding
  immediately. It is the finite-domain sibling of
  the substitution-based elimination already in the pipeline (`ex_subs_based_elimination`: one
  witness from `x = t`; here: one witness per cell the formula distinguishes), and it sits before
  the miniscoping of `72372947` rather than replacing it - meant as a companion to the block
  pipeline, not a bypass of it.

Off by default; `api::set_bv_case_split(true)` or `TAU_BV_CASE_SPLIT` (a value of "0" disables)
opt in, following the runtime-parameter pattern of `set_block_max_splits` (`10fface7`). The budget
stays what it is - the pass only takes this class off its path; our earlier run-path guard (#77,
superseded by that budget) was a bound on the same symptom, this is a rewrite of the cause.

Measured (same binary, switch off vs on, one 4-core Linux box, Release):

* the script from #107 at defaults: first step killed after 130 s (off) vs 0.37 s (on); with
  `--block-max-splits 1`: 0.11 s (off) vs 0.05 s (on) - less is left to re-wrap;
* 141 steps of that script: all 141 verdicts and every output-stream line (law/seal bytes)
  identical between off and on, with and without the budget; total run time unchanged
  (13.1 s vs 13.1 s);
* a 500-step accumulating run, compared the same way: all 500 verdicts and every output-stream
  line identical between off and on, with and without the budget; total 200 s (off, budget 1)
  vs 193 s (on, no budget) vs 199 s (on, budget 1), peak per-step 1.6 / 1.5 / 1.8 s;
* the split fires twice on that boundary step (the command, 3 cases; the result code, 5 cases);
  the innermost block then needs 37 splits instead of 151 and no block reaches the last-resort
  elimination with more than a few hundred nodes.
* `test_integration-bv_case_split` (new, 12 cases): normal forms with the switch off and on agree
  where the elimination applies (existential and universal over a tested command; two constants
  in both polarities; order tests cutting the domain into cells, including the boundary cells at
  both ends; independent parts attached once) and where it must decline (an arithmetic occurrence; a symbolic bound; a nested
  binder of the same variable), and a run with a bitvector command, lookback and initial
  condition produces identical outputs.
* Full suites on this branch (`a70ad0fa`): Release 521/521 and Debug 521/521 with the switch on, and
  521/521 / 521/521 with it off; no timeouts. One sample in the new test is checked against its
  expected normal form only: `ex x (x > 2 && x < 4 && (x = 3 -> a = 0))`, where the pipeline
  without the switch currently answers `T` (see #105).

Two things worth a look in review. The occurrence scan compares variable nodes structurally and
treats a comparison with `v` on both sides, or a nested binder of `v`, as disqualifying
(conservative); and the cells are computed on the base-2 digits of the constants in the unsigned
order, which is the order the blasting recurrence implements - if the bitvector order is meant to
be signed anywhere, that is the line to change.
The scan does not descend into BA constants, so a `:tau` constant carrying its own io variables
never contributes occurrences.