### PR TITLE
Add an opt-in quantifier-free decision for closed bitvector formulas with binders of one kind

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -168,6 +168,12 @@ struct api {
 	 */
 	static void set_block_max_splits(size_t n);
 	/**
+	 * @brief Enable/disable the quantifier-free decision of closed bitvector
+	 * formulas whose binders are all of one kind (bv_ba.h,
+	 * `bv_quantifier_free_decision`). Off by default.
+	 */
+	static void set_bv_quantifier_free_decision(bool state);
+	/**
 	 * @brief Set the anti-prenex driver's maximum round count.
 	 *
 	 * Bounds how many times the driver re-collects innermost blocks before

--- a/src/api.tmpl.h
+++ b/src/api.tmpl.h
@@ -90,6 +90,11 @@ void api<node>::set_block_max_splits(size_t n) {
 }
 
 template <NodeType node>
+void api<node>::set_bv_quantifier_free_decision(bool state) {
+	bv_quantifier_free_decision = state;
+}
+
+template <NodeType node>
 void api<node>::set_block_max_rounds(size_t n) {
 	block_max_rounds = n ? n : std::numeric_limits<size_t>::max();
 }

--- a/src/boolean_algebras/bv_ba.h
+++ b/src/boolean_algebras/bv_ba.h
@@ -36,6 +36,7 @@
 #ifndef __IDNI__TAU__CVC5_H__
 #define __IDNI__TAU__CVC5_H__
 
+#include <cstdlib>
 #include <cvc5/cvc5.h>
 
 #include "boolean_algebras/cvc5/cvc5.h"
@@ -66,6 +67,42 @@ using solution = subtree_map<node, tref>;
  */
 template<NodeType node>
 size_t get_bv_size(const tref t);
+
+/// Opt-in: decide a closed bitvector formula whose binders are all of one
+/// kind quantifier-free (see `bv_formula_sat_status`). A formula with only
+/// existential binders in positive polarity is satisfiable exactly when its
+/// matrix is (`sat(ex x phi) == sat(phi)` with `x` free); one with only
+/// universal binders is satisfiable exactly when the negated matrix is not
+/// (`sat(all x phi) == !sat(!phi)`). Such a formula is then handed to cvc5 in
+/// `QF_BV` with eager bitblasting instead of the quantified `BV` logic.
+/// Off by default; enabled via `api::set_bv_quantifier_free_decision(true)`
+/// or the environment variable TAU_BV_QF_DECISION (a value of "0" disables).
+inline bool bv_quantifier_free_decision = false;
+
+inline bool bv_quantifier_free_decision_enabled() {
+	static const bool env = [] {
+		const char* v = std::getenv("TAU_BV_QF_DECISION");
+		return v && *v && !(v[0] == '0' && v[1] == '\0');
+	}();
+	return bv_quantifier_free_decision || env;
+}
+
+/**
+ * @brief Configure a solver for a quantifier-free decision-only query.
+ *
+ * `QF_BV` with eager bitblasting: the whole formula goes to the SAT solver
+ * at once, which is what a closed, binder-free bitvector query wants. Models
+ * and proofs are never read by the callers of `bv_formula_sat_status`, and
+ * every instance performs exactly one checkSat, so incrementality is off as
+ * well. Only reachable through `bv_quantifier_free_decision`.
+ */
+inline void config_cvc5_solver_quantifier_free(cvc5::Solver& solver) {
+	solver.setOption("incremental", "false");
+	solver.setOption("produce-models", "false");
+	solver.setOption("produce-proofs", "false");
+	solver.setOption("bitblast", "eager");
+	solver.setLogic("QF_BV");
+}
 
 /**
  * @brief Configures the given cvc5 solver instance for bit-vector logic.

--- a/src/boolean_algebras/bv_ba_solver.tmpl.h
+++ b/src/boolean_algebras/bv_ba_solver.tmpl.h
@@ -521,6 +521,70 @@ std::optional<bv_sat_status> bv_formula_sat_status(tref form) {
 #endif // TAU_CACHE
 
 	subtree_map<node, bv> vars, free_vars;
+	// Opt-in quantifier-free decision (bv_quantifier_free_decision). A closed
+	// formula whose binders are all existential, all in positive polarity and
+	// each variable bound once, is satisfiable exactly when its matrix is, so
+	// the binders are dropped and the variables become free constants; one
+	// whose binders are all universal is satisfiable exactly when the negated
+	// matrix is unsatisfiable, so it is negated as well and the verdict
+	// inverted. Either way cvc5 then sees a QF_BV problem and bitblasts it
+	// eagerly, instead of running its quantifier instantiation on a formula
+	// that has no alternation to instantiate. Anything else -- both kinds,
+	// a binder under a negation, a variable bound twice -- takes the path
+	// below unchanged.
+	if (bv_quantifier_free_decision_enabled()) {
+		const bool has_ex = tau::get(form).find_top(is<node, tau::wff_ex>) != nullptr;
+		const bool has_all = tau::get(form).find_top(is<node, tau::wff_all>) != nullptr;
+		if (has_ex != has_all) {
+			const auto kind = has_ex ? tau::wff_ex : tau::wff_all;
+			bool eligible = true;
+			subtree_map<node, int> bound;
+			std::vector<std::pair<tref, bool>> stack{{form, false}};
+			while (!stack.empty() && eligible) {
+				auto [n, under_neg] = stack.back(); stack.pop_back();
+				if (!n) continue;
+				const tau& t = tau::get(n);
+				if (t.is(tau::wff_neg)) under_neg = true;
+				if (t.is(kind)) {
+					if (under_neg || !is<node>(t.first(), tau::variable)
+						|| ++bound[t.first()] > 1) eligible = false;
+				}
+				for (tref c : t.children()) stack.push_back({c, under_neg});
+			}
+			if (eligible) {
+				auto drop_binder = [kind](tref n) -> tref {
+					const tau& t = tau::get(n);
+					if (t.is(tau::wff) && t.child_is(kind)) return t[0].second();
+					return n;
+				};
+				tref matrix = form;
+				for (;;) { // binders nest; peel until none is left
+					tref next = pre_order<node>(matrix).apply_unique(drop_binder, while_is_formula<node>);
+					if (next == matrix) break;
+					matrix = next;
+				}
+				const bool invert = !has_ex;
+				if (invert) matrix = tau::build_wff_neg(matrix);
+				LOG_DEBUG << "bv_formula_sat_status: quantifier-free decision"
+					<< (invert ? " (universal, inverted)" : "") << ": " << LOG_FM(matrix);
+				cvc5::Solver qf_solver(cvc5_term_manager);
+				config_cvc5_solver_quantifier_free(qf_solver);
+				auto qf_expr = bv_eval_node<node>(tt(matrix), vars, free_vars);
+				if (!qf_expr) {
+					LOG_ERROR << "Failed to translate the formula to cvc5: " << LOG_FM(matrix);
+					return memo(std::nullopt);
+				}
+				qf_solver.assertFormula(qf_expr.value());
+				auto qf_result = qf_solver.checkSat();
+				if (qf_result.isSat()) return memo(invert ? bv_sat_status::unsat : bv_sat_status::sat);
+				if (qf_result.isUnknown()) {
+					LOG_DEBUG << "cvc5 could not decide satisfiability (unknown) for: " << qf_expr.value();
+					return memo(bv_sat_status::unknown);
+				}
+				return memo(invert ? bv_sat_status::sat : bv_sat_status::unsat);
+			}
+		}
+	}
 	// A fresh solver per query is deliberate, do NOT share one like
 	// normalize_bv's (B12): cvc5 forbids a second checkSat without
 	// incremental mode ("cannot make multiple queries unless incremental

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TESTS
 	bv_stress_check
 	ba_component_factoring
 	simp_tau_unsat_valid_unitwise
+	bv_quantifier_free_decision
 )
 
 foreach(X IN LISTS TESTS)

--- a/tests/integration/test_integration-bv_quantifier_free_decision.cpp
+++ b/tests/integration/test_integration-bv_quantifier_free_decision.cpp
@@ -1,0 +1,108 @@
+// To view the license please visit https://github.com/IDNI/tau-lang/blob/main/LICENSE.md
+
+// Quantifier-free decision of closed bitvector formulas whose binders are all
+// of one kind (bv_ba_solver.tmpl.h, opt-in). Dropping positive existential
+// binders keeps satisfiability, dropping positive universal binders and
+// negating the matrix inverts it, so the verdicts with the switch on must
+// equal the verdicts without it -- on the shapes it takes and on the shapes it
+// must leave alone (both kinds, a binder under a negation).
+
+#include "test_init.h"
+#include "test_tau_helpers.h"
+
+#include <cstdio>
+
+namespace {
+
+struct qf_config {
+	qf_config(bool on) { bv_quantifier_free_decision = on; }
+	~qf_config() { bv_quantifier_free_decision = false; }
+};
+
+tref parse_wff(const std::string& sample) {
+	static tree<node_t>::get_options opts{ .parse = { .start = tree<node_t>::wff }};
+	auto src = tree<node_t>::get(sample, opts);
+	if (src == nullptr) TAU_LOG_ERROR << "Parsing failed for: " << sample;
+	return src;
+}
+
+std::string norm(const std::string& sample, bool on) {
+	qf_config c(on);
+	auto wff = parse_wff(sample);
+	return wff ? tau::get(normalizer<node_t>(wff)).to_str() : "parse_error";
+}
+
+// A subset-sum over k guarded contributions: bv[1] selectors s_i, bv[8]
+// contributions c_i pinned to v_i or 0 by the selector, and a sum equal to
+// `target`. The first selector is forced to 1, so the smallest reachable sum
+// is 2 and the largest is 2 + 3 + ... + (k + 1).
+std::string subset_sum(size_t k, const std::string& quantifier, unsigned target) {
+	std::string vars, body;
+	for (size_t i = 0; i < k; ++i) {
+		std::string s = "s" + std::to_string(i) + ":bv[1]";
+		std::string c = "c" + std::to_string(i) + ":bv[8]";
+		vars += (i ? ", " : "") + s + ", " + c;
+		char v[8]; std::snprintf(v, sizeof v, "%02x", (unsigned) (2 + i));
+		body += "(" + s + " = { #x1 }:bv[1] -> " + c + " = { #x" + v + " }:bv[8]) && ("
+			+ s + " = { #x0 }:bv[1] -> " + c + " = { #x00 }:bv[8]) && ";
+	}
+	std::string sum;
+	for (size_t i = 0; i < k; ++i) sum += (i ? " + " : "") + ("c" + std::to_string(i) + ":bv[8]");
+	char t[8]; std::snprintf(t, sizeof t, "%02x", target);
+	return quantifier + " " + vars + " (" + body + "s0:bv[1] = { #x1 }:bv[1] && "
+		+ sum + " = { #x" + t + " }:bv[8])";
+}
+
+} // namespace
+
+TEST_SUITE("configuration") {
+	TEST_CASE("bdd_init") { bdd_init<Bool>(); }
+	TEST_CASE("logging") { logging::trace(); }
+}
+
+TEST_SUITE("quantifier-free bitvector decision") {
+
+	TEST_CASE("existential closure: same verdicts as the quantified path") {
+		// target 2: only the forced first contribution -- satisfiable.
+		CHECK(norm(subset_sum(6, "ex", 2), true) == "T");
+		CHECK(norm(subset_sum(6, "ex", 2), false) == "T");
+		// target 255: above the largest reachable sum (2 + ... + 7 = 27).
+		CHECK(norm(subset_sum(6, "ex", 255), true) == "F");
+		CHECK(norm(subset_sum(6, "ex", 255), false) == "F");
+		// target 27: everything on.
+		CHECK(norm(subset_sum(6, "ex", 27), true) == "T");
+		CHECK(norm(subset_sum(6, "ex", 27), false) == "T");
+	}
+
+	TEST_CASE("universal closure: inverted matrix, same verdicts") {
+		// Not every assignment sums to 2, and none sums to 255, so both are F.
+		CHECK(norm(subset_sum(6, "all", 2), true) == "F");
+		CHECK(norm(subset_sum(6, "all", 2), false) == "F");
+		// A universal tautology over the bitvector order.
+		CHECK(norm("all x:bv[4] (x:bv[4] < { 3 }:bv[4] || x:bv[4] >= { 3 }:bv[4])", true) == "T");
+		CHECK(norm("all x:bv[4] (x:bv[4] < { 3 }:bv[4] || x:bv[4] >= { 3 }:bv[4])", false) == "T");
+		CHECK(norm("all x:bv[4] (x:bv[4] < { 3 }:bv[4])", true) == "F");
+		CHECK(norm("all x:bv[4] (x:bv[4] < { 3 }:bv[4])", false) == "F");
+	}
+
+	TEST_CASE("the larger instance the quantified path does not finish in time") {
+		// 14 contributions: the quantified path took over a minute per query
+		// on the box this was measured on; here it decides in milliseconds.
+		CHECK(norm(subset_sum(14, "ex", 2), true) == "T");
+		CHECK(norm(subset_sum(14, "ex", 255), true) == "F");
+		CHECK(norm(subset_sum(14, "all", 255), true) == "F");
+	}
+
+	TEST_CASE("left alone: both kinds, or a binder under a negation") {
+		// Alternation: the quantified path, with and without the switch.
+		CHECK(norm("all x:bv[2] ex y:bv[2] (y:bv[2] > x:bv[2])", true) == "F");
+		CHECK(norm("all x:bv[2] ex y:bv[2] (y:bv[2] > x:bv[2])", false) == "F");
+		CHECK(norm("ex y:bv[2] all x:bv[2] (y:bv[2] >= x:bv[2])", true) == "T");
+		CHECK(norm("ex y:bv[2] all x:bv[2] (y:bv[2] >= x:bv[2])", false) == "T");
+		// A negated existential is a universal in disguise: declined, same verdict.
+		CHECK(norm("!(ex x:bv[4] (x:bv[4] > { 14 }:bv[4]))", true) == "F");
+		CHECK(norm("!(ex x:bv[4] (x:bv[4] > { 14 }:bv[4]))", false) == "F");
+		CHECK(norm("!(ex x:bv[4] (x:bv[4] > { 15 }:bv[4]))", true) == "T");
+		CHECK(norm("!(ex x:bv[4] (x:bv[4] > { 15 }:bv[4]))", false) == "T");
+	}
+}


### PR DESCRIPTION
Addresses #109.

`bv_formula_sat_status` hands a closed bitvector formula to cvc5 with its binders, in logic
`BV`. For a formula whose binders are all existential - the shape the interpreter's closure over
bitvector outputs takes at the fixpoint check - cvc5 then runs its quantifier instantiation on a
problem that has no alternation to instantiate: the guarded subset-sum in #109 over 14
`bv[8]` contributions selected by `bv[1]` flags spends 66 s in one checkSat, and over 20
contributions it does not return within two minutes. The same matrix with the binders dropped,
in `QF_BV` with eager bitblasting, decides in 10-20 ms.

The change, at the top of `bv_formula_sat_status`, behind an opt-in switch:

* If the formula's binders are all of one kind, all in positive polarity (no `wff_neg` above a
  binder) and every variable bound once, the binders are peeled off and the matrix is decided
  quantifier-free: for existential binders directly, since `sat(ex x phi) == sat(phi)` with `x`
  free; for universal binders on the negated matrix with the verdict inverted, since
  `sat(all x phi) == !sat(!phi)`. Both are identities, so no verdict can change; an `unknown`
  from cvc5 stays `unknown`.
* The solver for that query is configured `QF_BV`, `bitblast=eager`, no models, no proofs, not
  incremental - the callers of this function only ever read the verdict (the same reasoning as
  `decision_no_models`), and eager bitblasting is what a binder-free bitvector problem wants.
* Anything else - both binder kinds, a binder under a negation, a variable bound twice - takes
  the existing path unchanged, including the alternation gate
  (`config_cvc5_solver_alternating_quantifiers`) and the measured option set: those were tuned on
  alternating queries, and this pass only takes the non-alternating ones off that path.

Off by default; `api::set_bv_quantifier_free_decision(true)` or `TAU_BV_QF_DECISION` (a value of
"0" disables) opt in, following the runtime-parameter pattern of the other solver knobs.

Measured (same binary, switch off vs on, one 4-core Linux box, Release, no other load):

* the script from #109, 14 contributions, `sat`: 81 s (off, the cvc5 call 66 s) vs 1.2 s
  (on, the call 63 ms); the unsatisfiable target and the `valid` form: killed at 120 s (off) vs
  1.1 s / 1.2 s (on); 20 contributions: killed at 120 s (off) vs 2.1 s (on) for all three;
  10 contributions: 1.0-1.9 s vs 0.7-0.8 s. Every verdict the quantified path returned is the
  same on both sides.
* two long `run`s over specs mixing `:tau` and `:bv[8]` streams (141 steps of a 137-clause step
  spec, and a 500-step accumulating one): every verdict and every output-stream line identical
  off and on, times and peak memory unchanged (13.2 s vs 12.5 s and 203 s vs 208 s wall, peak RSS 52 vs 52 MB
  and 147 vs 148 MB).
* `test_integration-bv_quantifier_free_decision` (new, 6 cases, 23 checks): existential and
  universal closures of the subset-sum agree with the quantified path on satisfiable and
  unsatisfiable targets, universal tautologies and their negations agree, the 14-contribution
  instance decides, and the shapes the pass must leave alone (alternation in both orders, a
  negated existential) give the same verdicts with the switch on and off.
* Full suites on this branch: Release 521/521 and Debug 521/521 with the switch on, and the same
  521/521 / 521/521 with it off; no timeouts.

Two things worth a look in review. The eligibility scan treats a binder under any `wff_neg` as
disqualifying, which is conservative (a negated universal is an existential and could be taken
after pushing the negation in - left out to keep the pass a pure binder peel); and the peel
keeps the cache key of `bv_formula_sat_status` on the original formula, so a formula decided
quantifier-free once is served from the same memo as before.